### PR TITLE
Simplify XSD parser and adopt trailing-underscore helper naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ per XSD construct in `Elements/*.cpp`. **Visitor:** `BaseProcessor`
 calls the matching `p.ProcessXxx(this)`, `ParseChildren(p)` recurses — compile-time
 dispatch, no RTTI. **Types:** `TypesDB` (builtin XSD primitives, keyed by **local
 name only — no namespace**) + a `Types::BaseType` hierarchy; refs resolve
-structurally in `Node::_Type`/`_FindXSDElm`, scoped to the current doc +
+structurally in `Node::Type_`/`FindXSDElm_`, scoped to the current doc +
 `xs:include`s.
 
 **Processors** (`src/Processors/`): `LuaProcessorBase` (BaseProcessor impl, most
@@ -61,7 +61,7 @@ Multi-file output uses `/* FILE: name */` markers.
 - **Match the existing spacing and naming of the file/area you edit; don't
   reformat surrounding code.** C++ uses **tab indentation**; pointers are `p`-
   prefixed (`pNode`), references `r`-prefixed (`rProcessor`), members `m_`,
-  private helpers `_`-prefixed (`_FindXSDElm`), methods PascalCase
+  private helpers `_`-**suffixed** (`FindXSDElm_`), methods PascalCase
   (`ParseElement`), macros UPPER_CASE. CMake uses 2-space indent; Lua templates
   follow their existing local style. New files mirror their closest neighbor.
 - **Output targets are template-only** — copy the closest existing target and

--- a/src/Processors/ElementExtracter.cpp
+++ b/src/Processors/ElementExtracter.cpp
@@ -56,7 +56,7 @@ ElementExtracter::Extract(const Schema& rDocRoot) {
 /* virtual */ void 
 ElementExtracter::ProcessSchema(const Schema* pNode) {
 	/* different iterator accross the schema children */
-	pNode->_eachChild([&](const Node& rNode) {
+	pNode->eachChild_([&](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Element) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Include) ||

--- a/src/Processors/LuaAdapter.cpp
+++ b/src/Processors/LuaAdapter.cpp
@@ -51,9 +51,9 @@ LuaFacets::addToList(const std::string& rName, const std::string& rValue) {
 }
 
 /* helper functions */
-static void _luaStackDump(lua_State * pLuaState);
+static void luaStackDump_(lua_State * pLuaState);
 #if (DEBUG_LUASTACK)
-static void _luaStackDumpRec(lua_State * pLuaState, int stackIndex = 0);
+static void luaStackDumpRec_(lua_State * pLuaState, int stackIndex = 0);
 #endif
 /* Class method definitions */
 /* Class LuaAdapter */
@@ -71,12 +71,12 @@ LuaAdapter::Schema() {
 }
 
 lua_State *
-LuaAdapter::_getLuaState() {
+LuaAdapter::getLuaState_() {
   return m_pLuaState;
 }
 
 void
-LuaAdapter::_setLuaState(lua_State * pLuaState) {
+LuaAdapter::setLuaState_(lua_State * pLuaState) {
 	m_pLuaState = pLuaState;
 }
 
@@ -93,19 +93,19 @@ LuaContent::LuaContent(lua_State* pLuaState)
 
 /* virtual */
 LuaContent::~LuaContent() {  
-	lua_pop(_getLuaState(), 1);
+	lua_pop(getLuaState_(), 1);
 }
 
 LuaType *
 LuaContent::Type(const std::string& rTypeName, const int maxOccurs,
                  const int minOccurs) {
-	return new LuaType(_getLuaState(), rTypeName, maxOccurs, minOccurs);
+	return new LuaType(getLuaState_(), rTypeName, maxOccurs, minOccurs);
 }
 
 /* Class LuaSchema */
 LuaSchema::LuaSchema(lua_State* pLuaState) {
 	/* set the lua state without calling the content constructor */
-	_setLuaState(pLuaState);
+	setLuaState_(pLuaState);
 	/* test if global table has been made & make it if not */
 	lua_getglobal(pLuaState, SCHEMA_TAG);
 	if (lua_isnil(pLuaState, -1)) {
@@ -115,7 +115,7 @@ LuaSchema::LuaSchema(lua_State* pLuaState) {
 		lua_getglobal(pLuaState, SCHEMA_TAG);
 	}
 	/* debug */
-	_luaStackDump(pLuaState);
+	luaStackDump_(pLuaState);
 }
 
 /* virtual */
@@ -143,12 +143,12 @@ LuaType::LuaType(lua_State* pLuaState, const std::string& rTypeName,
 	lua_pushnumber(pLuaState, minOccurs);
 	lua_setfield(pLuaState, -2, MINOCCURS_TAG);
 	/* debug */
-	_luaStackDump(pLuaState);
+	luaStackDump_(pLuaState);
 }
 
 /* virtual */
 LuaType::~LuaType() { 
-	lua_pop(_getLuaState(), 1);
+	lua_pop(getLuaState_(), 1);
 }
 
 LuaAttribute *
@@ -157,12 +157,12 @@ LuaType::Attribute(	const string& rName,
 					const std::string * pDefault,
 					const std::string * pFixed,
 					const std::string * pUse) {
-	return new LuaAttribute(_getLuaState(), rName, rType, pDefault, pFixed, pUse);
+	return new LuaAttribute(getLuaState_(), rName, rType, pDefault, pFixed, pUse);
 }
 
 LuaContent *
 LuaType::Content() {
-	return new LuaContent(_getLuaState());
+	return new LuaContent(getLuaState_());
 }
 
 void
@@ -170,7 +170,7 @@ LuaType::Facets(const LuaFacets& rFacets) {
 	/* only emit a `facets` block when there is something to emit */
 	if (rFacets.empty())
 		return;
-	lua_State * pLuaState = _getLuaState();
+	lua_State * pLuaState = getLuaState_();
 	/* type table is at stack top; build facets sub-table */
 	lua_newtable(pLuaState);
 	for (size_t i = 0; i < rFacets.scalars.size(); ++i) {
@@ -188,7 +188,7 @@ LuaType::Facets(const LuaFacets& rFacets) {
 	}
 	lua_setfield(pLuaState, -2, FACETS_TAG);
 	/* debug */
-	_luaStackDump(pLuaState);
+	luaStackDump_(pLuaState);
 }
 
 /* Class LuaAttribute */
@@ -224,7 +224,7 @@ LuaAttribute::LuaAttribute(	lua_State * pLuaState,
 	/* append attribute to attribute table */
 	lua_setfield(pLuaState, -2, rName.c_str());
 	/* debug */
-	_luaStackDump(pLuaState);
+	luaStackDump_(pLuaState);
 }
 
 void
@@ -232,7 +232,7 @@ LuaAttribute::Facets(const LuaFacets& rFacets) {
 	/* only emit a `facets` block when there is something to emit */
 	if (rFacets.empty())
 		return;
-	lua_State * pLuaState = _getLuaState();
+	lua_State * pLuaState = getLuaState_();
 	/* the ATTRIBUTE_TAG table is at stack top; descend attributes[name] ->
 	   [typeName] so facets land on the type sub-table (where targets read
 	   attr.<type>.facets, mirroring content-type facets) */
@@ -256,24 +256,24 @@ LuaAttribute::Facets(const LuaFacets& rFacets) {
 	/* pop the type + attribute tables, restoring ATTRIBUTE_TAG at top */
 	lua_pop(pLuaState, 2);
 	/* debug */
-	_luaStackDump(pLuaState);
+	luaStackDump_(pLuaState);
 }
 
 /* virtual */
 LuaAttribute::~LuaAttribute() {
-	lua_pop(_getLuaState(), 1);
+	lua_pop(getLuaState_(), 1);
 }
 
-static void _luaStackDump(lua_State * pLuaState) {
+static void luaStackDump_(lua_State * pLuaState) {
 #if (DEBUG_LUASTACK)
 	cout << "LStack:[";
-	_luaStackDumpRec(pLuaState, 0);
+	luaStackDumpRec_(pLuaState, 0);
 	cout << "]" << endl;
 #endif
 }
 
 #if (DEBUG_LUASTACK)
-static void _luaStackDumpRec(lua_State * pLuaState, int stackIndex) {
+static void luaStackDumpRec_(lua_State * pLuaState, int stackIndex) {
 	const int stkTop = lua_gettop(pLuaState);
 	/* base case */
 	if (stackIndex == stkTop) 
@@ -317,6 +317,6 @@ static void _luaStackDumpRec(lua_State * pLuaState, int stackIndex) {
 		break;
 	}
 	cout << " ";
-	_luaStackDumpRec(pLuaState, stackIndex + 1);
+	luaStackDumpRec_(pLuaState, stackIndex + 1);
 }
 #endif

--- a/src/Processors/LuaAdapter.hpp
+++ b/src/Processors/LuaAdapter.hpp
@@ -67,8 +67,8 @@ namespace Processors {
 		virtual ~LuaAdapter();
 		LuaSchema * Schema();
 	protected:
-		lua_State * _getLuaState();
-		void _setLuaState(lua_State * pLuaState);
+		lua_State * getLuaState_();
+		void setLuaState_(lua_State * pLuaState);
 	private:
 		lua_State *	m_pLuaState;
 		LuaAdapter(const LuaAdapter&);

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -86,7 +86,7 @@ LuaProcessor::~LuaProcessor() {
 LuaProcessor::ProcessSchema(const XSD::Elements::Schema* pNode) {
 	if (pNode->isRootSchema()) {
 		/* create root schema table and append it to stack */
-		LuaProcessor processor(_luaAdapter()->Schema());
+		LuaProcessor processor(luaAdapter_()->Schema());
 		pNode->ParseChildren(processor);
 	} else {
 		/* parse schema children */
@@ -104,10 +104,10 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 		unique_ptr<XSD::Types::BaseType> pElmType(pNode->Type());
 		/* process element type */
 		/* inserts basic type. Handle array types the same as basic types */
-		LuaContent * pLuaContent = dynamic_cast<LuaContent*>(_luaAdapter());
+		LuaContent * pLuaContent = dynamic_cast<LuaContent*>(luaAdapter_());
 		if (NULL == pLuaContent) {
 			/* enter the type content table & add elements, then leave */
-			LuaType * pLuaType = dynamic_cast<LuaType*>(_luaAdapter());
+			LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
 			LuaProcessor processor(pLuaType->Content());
 			processor.ProcessElement(pNode);
 		} else {
@@ -116,7 +116,7 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 			int minOccurs = pNode->HasMinOccurs() ?	pNode->MinOccurs() : 1;
 			LuaProcessor luaPrcssr(
 				pLuaContent->Type(pNode->Name(), maxOccurs, minOccurs));
-			luaPrcssr._parseType(*pElmType);
+			luaPrcssr.parseType_(*pElmType);
 		}
 	} else {
 		unique_ptr<XSD::Elements::Element> pRefElm(pNode->RefElement());
@@ -126,7 +126,7 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 
 /* virtual */ void
 LuaProcessor::ProcessUnion(const XSD::Elements::Union* pNode) {
-	_parseType(XSD::Types::String());
+	parseType_(XSD::Types::String());
 }
 
 /* virtual */ void
@@ -137,25 +137,25 @@ LuaProcessor::ProcessRestriction(const XSD::Elements::Restriction* pNode ) {
 	} else if (pNode->isParentSimpleContent()) {
 		pNode->ParseChildren(*this);
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Base());
-		_parseType(*pType);
+		parseType_(*pType);
 	} else {
 		/* Walk facet children directly (accumulating onto m_facets across
 		   the derivation chain) before resolving the base type. Bypasses
 		   Restriction::ParseChildren, whose numeric-base verification
-		   rejects valid facets on integer-derived types. _parseType
+		   rejects valid facets on integer-derived types. parseType_
 		   recurses through nested restrictions on this same processor, so
 		   facets from every level land on the leaf type. */
-		_walkFacets(pNode);
+		walkFacets_(pNode);
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Base());
-		_parseType(*pType);
+		parseType_(*pType);
 	}
 }
 
 /* Dispatch each facet child of a simpleType restriction to this processor,
    so the ProcessXxx facet overrides record their values. */
 void
-LuaProcessor::_walkFacets(const XSD::Elements::Node* pNode) {
-	pNode->_eachChild([this](const XSD::Elements::Node& rChild) {
+LuaProcessor::walkFacets_(const XSD::Elements::Node* pNode) {
+	pNode->eachChild_([this](const XSD::Elements::Node& rChild) {
 		if (XSD_ISELEMENT(&rChild, XSD::Elements::MinExclusive) ||
 			XSD_ISELEMENT(&rChild, XSD::Elements::MaxExclusive) ||
 			XSD_ISELEMENT(&rChild, XSD::Elements::MinInclusive) ||
@@ -179,7 +179,7 @@ LuaProcessor::ProcessList(const XSD::Elements::List* pNode) {
 	/* extract xsd native type from simple type */
 	SimpleTypeExtracter typeXtr;
 	/* create array type */
-	_parseType(Types::ArrayType(typeXtr.Extract(*pTypeLst)));
+	parseType_(Types::ArrayType(typeXtr.Extract(*pTypeLst)));
 }
 
 /* virtual */ void 
@@ -201,7 +201,7 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		/* extract xsd native type from simple type and add it */
 		SimpleTypeExtracter typeXtr;
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Type());
-		LuaType * pLuaType = dynamic_cast<LuaType*>(_luaAdapter());
+		LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
 		unique_ptr<string> pDefault(nullptr);
 		unique_ptr<string> pFixed(nullptr);
 		unique_ptr<string> pUse(new string("optional"));
@@ -239,7 +239,7 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		/* bridge the attribute's restriction facets (clear first so prior
 		   content facets don't leak in), then attach to the attribute */
 		m_facets.clear();
-		_walkAttributeFacets(pType.get());
+		walkAttributeFacets_(pType.get());
 		pAttribute->Facets(m_facets);
 		m_facets.clear();
 	}
@@ -250,7 +250,7 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
    itself a user-defined simpleType (covers inline and named-type
    attributes uniformly: both resolve to a Types::SimpleType). */
 void
-LuaProcessor::_walkAttributeFacets(const XSD::Types::BaseType* pType) {
+LuaProcessor::walkAttributeFacets_(const XSD::Types::BaseType* pType) {
 	if (!(XSD_ISTYPE(pType, XSD::Types::SimpleType)))
 		return;
 	const XSD::Types::SimpleType* pSimpleType =
@@ -259,11 +259,11 @@ LuaProcessor::_walkAttributeFacets(const XSD::Types::BaseType* pType) {
 	unique_ptr<XSD::Elements::Restriction> pRestriction(pElm->GetRestriction());
 	if (NULL == pRestriction.get())
 		return;
-	_walkFacets(pRestriction.get());
+	walkFacets_(pRestriction.get());
 	/* follow the chain when the base is another user-defined simpleType */
 	unique_ptr<XSD::Types::BaseType> pBase(pRestriction->Base());
 	if (XSD_ISTYPE(pBase.get(), XSD::Types::SimpleType))
-		_walkAttributeFacets(pBase.get());
+		walkAttributeFacets_(pBase.get());
 }
 
 /* virtual */ void 
@@ -271,10 +271,10 @@ LuaProcessor::ProcessComplexType(const XSD::Elements::ComplexType* pNode) {
 	/* add a string to the content type if it is mixed mode */
 	if (pNode->Mixed()) {
 		/* inserts basic type. Handle array types the same as basic types */
-		LuaContent * pLuaContent = dynamic_cast<LuaContent*>(_luaAdapter());
+		LuaContent * pLuaContent = dynamic_cast<LuaContent*>(luaAdapter_());
 		if (NULL == pLuaContent) {
 			/* enter the type content table & add elements, then leave */
-			LuaType * pLuaType = dynamic_cast<LuaType*>(_luaAdapter());
+			LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
 			LuaProcessor processor(pLuaType->Content());
 			processor.ProcessComplexType(pNode);
 		} else {
@@ -315,7 +315,7 @@ LuaProcessor::ProcessAny(const XSD::Elements::Any* pNode) {
 /* virtual */ void
 LuaProcessor::ProcessExtension(const XSD::Elements::Extension* pNode) {
 	unique_ptr<XSD::Types::BaseType> pBase(pNode->Base());
-	_parseType(*pBase);
+	parseType_(*pBase);
 	pNode->ParseChildren(*this);
 }
 
@@ -342,7 +342,7 @@ LuaProcessor::ProcessAll(const XSD::Elements::All * pNode) {
 namespace {
 	/* stringify a numeric facet value (ostream drops trailing zeros) */
 	template <typename T>
-	string _numStr(T val) {
+	string numStr_(T val) {
 		ostringstream ss;
 		ss << val;
 		return ss.str();
@@ -352,55 +352,55 @@ namespace {
 /* virtual */ void
 LuaProcessor::ProcessMinExclusive(const XSD::Elements::MinExclusive* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("minExclusive", _numStr(pNode->Value()));
+		m_facets.addScalar("minExclusive", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessMaxExclusive(const XSD::Elements::MaxExclusive* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("maxExclusive", _numStr(pNode->Value()));
+		m_facets.addScalar("maxExclusive", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessMinInclusive(const XSD::Elements::MinInclusive* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("minInclusive", _numStr(pNode->Value()));
+		m_facets.addScalar("minInclusive", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessMaxInclusive(const XSD::Elements::MaxInclusive* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("maxInclusive", _numStr(pNode->Value()));
+		m_facets.addScalar("maxInclusive", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessMinLength(const XSD::Elements::MinLength* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("minLength", _numStr(pNode->Value()));
+		m_facets.addScalar("minLength", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessMaxLength(const XSD::Elements::MaxLength* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("maxLength", _numStr(pNode->Value()));
+		m_facets.addScalar("maxLength", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessLength(const XSD::Elements::Length* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("length", _numStr(pNode->Value()));
+		m_facets.addScalar("length", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessTotalDigits(const XSD::Elements::TotalDigits* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("totalDigits", _numStr(pNode->Value()));
+		m_facets.addScalar("totalDigits", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
 LuaProcessor::ProcessFractionDigits(const XSD::Elements::FractionDigits* pNode) {
 	if (pNode->HasValue())
-		m_facets.addScalar("fractionDigits", _numStr(pNode->Value()));
+		m_facets.addScalar("fractionDigits", numStr_(pNode->Value()));
 }
 
 /* virtual */ void
@@ -429,7 +429,7 @@ LuaProcessor::ProcessPattern(const XSD::Elements::Pattern* pNode) {
 }
 
 /* virtual */ void
-LuaProcessor::_parseType(const XSD::Types::BaseType& rXSDType) {
+LuaProcessor::parseType_(const XSD::Types::BaseType& rXSDType) {
 	if(XSD_ISTYPE(&rXSDType, XSD::Types::SimpleType)) {
 		const XSD::Types::SimpleType* pSimpleType = 
 			dynamic_cast<const XSD::Types::SimpleType*>(&rXSDType);
@@ -440,7 +440,7 @@ LuaProcessor::_parseType(const XSD::Types::BaseType& rXSDType) {
 		pComplexType->m_pValue->ParseElement(*this);
 	} else {
 		/* inserts basic type. Handles array types the same as basic types */
-		LuaType * pLuaType = dynamic_cast<LuaType*>(_luaAdapter());
+		LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
 		unique_ptr<LuaContent> pLuaContent(pLuaType->Content());
 		unique_ptr<LuaType> pLeaf(pLuaContent->Type(rXSDType.Name(), 1));
 		/* attach facets accumulated over the restriction chain, then reset */

--- a/src/Processors/LuaProcessor.hpp
+++ b/src/Processors/LuaProcessor.hpp
@@ -66,13 +66,13 @@ namespace Processors {
 		virtual void ProcessWhiteSpace(const XSD::Elements::WhiteSpace* pNode);
 	protected:
 		LuaProcessor(LuaAdapter * pLuaAdapter);
-		virtual void _parseType(const XSD::Types::BaseType& rXSDType);
+		virtual void parseType_(const XSD::Types::BaseType& rXSDType);
 	private:
 		LuaProcessor();
 		/* dispatch a restriction's facet children to this processor */
-		void _walkFacets(const XSD::Elements::Node* pNode);
+		void walkFacets_(const XSD::Elements::Node* pNode);
 		/* accumulate an attribute's restriction facets onto m_facets */
-		void _walkAttributeFacets(const XSD::Types::BaseType* pType);
+		void walkAttributeFacets_(const XSD::Types::BaseType* pType);
 		/* facets accumulated across a restriction derivation chain */
 		LuaFacets m_facets;
 	};

--- a/src/Processors/LuaProcessorBase.cpp
+++ b/src/Processors/LuaProcessorBase.cpp
@@ -75,172 +75,53 @@ LuaProcessorBase::~LuaProcessorBase() {
 	delete m_pLuaAdapter;
 }
 
-/* virtual */ void
-LuaProcessorBase::ProcessSchema(const XSD::Elements::Schema* pNode) {
-	pNode->ParseChildren(*this);
-}
-	
-/* virtual */ void 
-LuaProcessorBase::ProcessElement(const XSD::Elements::Element* pNode) {
-	pNode->ParseChildren(*this);
-}
-	
-/* virtual */ void
-LuaProcessorBase::ProcessUnion(const XSD::Elements::Union* pNode) {
-	pNode->ParseChildren(*this);
-}
-	
-/* virtual */ void
-LuaProcessorBase::ProcessRestriction(const XSD::Elements::Restriction* pNode ) {
-	pNode->ParseChildren(*this);
-}
-	
-/* virtual */ void
-LuaProcessorBase::ProcessList(const XSD::Elements::List* pNode) {
-	pNode->ParseChildren(*this);
-}
+/* Every base callback just recurses into the node's children. Enumerate the
+ * (ProcessXxx, element type) pairs once and stamp out the bodies. */
+#define LUA_PROC_BASE_CALLBACKS(X) \
+	X(ProcessSchema,         Schema) \
+	X(ProcessElement,        Element) \
+	X(ProcessUnion,          Union) \
+	X(ProcessRestriction,    Restriction) \
+	X(ProcessList,           List) \
+	X(ProcessSequence,       Sequence) \
+	X(ProcessChoice,         Choice) \
+	X(ProcessAttribute,      Attribute) \
+	X(ProcessSimpleType,     SimpleType) \
+	X(ProcessComplexType,    ComplexType) \
+	X(ProcessGroup,          Group) \
+	X(ProcessAny,            Any) \
+	X(ProcessComplexContent, ComplexContent) \
+	X(ProcessExtension,      Extension) \
+	X(ProcessSimpleContent,  SimpleContent) \
+	X(ProcessMinExclusive,   MinExclusive) \
+	X(ProcessMaxExclusive,   MaxExclusive) \
+	X(ProcessMinInclusive,   MinInclusive) \
+	X(ProcessMaxInclusive,   MaxInclusive) \
+	X(ProcessMinLength,      MinLength) \
+	X(ProcessMaxLength,      MaxLength) \
+	X(ProcessLength,         Length) \
+	X(ProcessEnumeration,    Enumeration) \
+	X(ProcessFractionDigits, FractionDigits) \
+	X(ProcessPattern,        Pattern) \
+	X(ProcessTotalDigits,    TotalDigits) \
+	X(ProcessWhiteSpace,     WhiteSpace) \
+	X(ProcessAttributeGroup, AttributeGroup) \
+	X(ProcessInclude,        Include) \
+	X(ProcessAnnotation,     Annotation) \
+	X(ProcessDocumentation,  Documentation) \
+	X(ProcessAll,            All) \
+	X(ProcessAppInfo,        AppInfo)
 
-/* virtual */ void
-LuaProcessorBase::ProcessSequence(const XSD::Elements::Sequence* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessChoice(const XSD::Elements::Choice* pNode ) {
-	pNode->ParseChildren(*this);
-}
-	
-/* virtual */ void
-LuaProcessorBase::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessSimpleType(const XSD::Elements::SimpleType* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessComplexType(const XSD::Elements::ComplexType* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessGroup(const XSD::Elements::Group* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessAny(const XSD::Elements::Any* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessComplexContent(const XSD::Elements::ComplexContent* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessExtension(const XSD::Elements::Extension* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessSimpleContent(const XSD::Elements::SimpleContent* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMinExclusive(const XSD::Elements::MinExclusive* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMaxExclusive(const XSD::Elements::MaxExclusive* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMinInclusive(const XSD::Elements::MinInclusive* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMaxInclusive(const XSD::Elements::MaxInclusive* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMinLength(const XSD::Elements::MinLength* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessMaxLength(const XSD::Elements::MaxLength* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessLength(const XSD::Elements::Length* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessEnumeration(const XSD::Elements::Enumeration* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void 
-LuaProcessorBase::ProcessFractionDigits(const XSD::Elements::FractionDigits* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void 
-LuaProcessorBase::ProcessPattern(const XSD::Elements::Pattern* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void 
-LuaProcessorBase::ProcessTotalDigits(const XSD::Elements::TotalDigits* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void 
-LuaProcessorBase::ProcessWhiteSpace(const XSD::Elements::WhiteSpace* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessAttributeGroup(const XSD::Elements::AttributeGroup* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessInclude(const XSD::Elements::Include* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessAnnotation(const XSD::Elements::Annotation* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessDocumentation(const XSD::Elements::Documentation* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessAll(const XSD::Elements::All* pNode) {
-	pNode->ParseChildren(*this);
-}
-
-/* virtual */ void
-LuaProcessorBase::ProcessAppInfo(const XSD::Elements::AppInfo* pNode) {
-	pNode->ParseChildren(*this);
-}
+#define LUA_PROC_BASE_DEFN(METHOD, TYPE) \
+	/* virtual */ void \
+	LuaProcessorBase::METHOD(const XSD::Elements::TYPE* pNode) { \
+		pNode->ParseChildren(*this); \
+	}
+LUA_PROC_BASE_CALLBACKS(LUA_PROC_BASE_DEFN)
+#undef LUA_PROC_BASE_DEFN
+#undef LUA_PROC_BASE_CALLBACKS
 
 LuaAdapter *
-LuaProcessorBase::_luaAdapter() const {
+LuaProcessorBase::luaAdapter_() const {
 	return m_pLuaAdapter;
 }

--- a/src/Processors/LuaProcessorBase.hpp
+++ b/src/Processors/LuaProcessorBase.hpp
@@ -70,7 +70,7 @@ namespace Processors {
 		virtual void ProcessAll(const XSD::Elements::All* pNode);
 		virtual void ProcessAppInfo(const XSD::Elements::AppInfo* pNode);
 	protected:
-		LuaAdapter *  	_luaAdapter() const;
+		LuaAdapter *  	luaAdapter_() const;
 	private:
 		mutable LuaAdapter * m_pLuaAdapter;
 	};

--- a/src/Processors/RestrictionVerify.cpp
+++ b/src/Processors/RestrictionVerify.cpp
@@ -70,7 +70,7 @@ RestrictionVerify::Verify(const Restriction* pRestriciton, const ComplexType* pP
 /* virtual */ void 
 RestrictionVerify::ProcessElement(const Element* pNode) {
 	/* find the element in the parent sub-tree */
-	bool bFound = m_pSubTree->_findChild([&](const Node& rSearchNode) -> bool {
+	bool bFound = m_pSubTree->findChild_([&](const Node& rSearchNode) -> bool {
 		if (XSD_ISELEMENT(&rSearchNode, Element)) {
 			const Element * pElement = static_cast<const Element *>(&rSearchNode);
 			if (pNode->HasRef() && pElement->HasRef()) {
@@ -126,7 +126,7 @@ RestrictionVerify::ProcessRestriction(const XSD::Elements::Restriction* pNode) {
 /* virtual */ void 
 RestrictionVerify::ProcessSequence(const XSD::Elements::Sequence* pNode) {
 	/* valid restrictions are xs:sequence to xs:sequence or xs:choice to xs:sequence */
-	bool bFound = m_pSubTree->_findChild([&](const Node& rSearchNode) -> bool {
+	bool bFound = m_pSubTree->findChild_([&](const Node& rSearchNode) -> bool {
 		if (XSD_ISELEMENT(&rSearchNode, Sequence) ||
 			XSD_ISELEMENT(&rSearchNode, Choice)) {
 			RestrictionVerify processor(&rSearchNode);
@@ -142,7 +142,7 @@ RestrictionVerify::ProcessSequence(const XSD::Elements::Sequence* pNode) {
 /* virtual */ void 
 RestrictionVerify::ProcessChoice(const XSD::Elements::Choice* pNode) {
 	/* search for either a xs:choice and verify that it is in the sub-tree */
-	bool bFound = m_pSubTree->_findChild([&](const Node& rSearchNode) -> bool {
+	bool bFound = m_pSubTree->findChild_([&](const Node& rSearchNode) -> bool {
 		if (XSD_ISELEMENT(&rSearchNode, Choice)) {
 			RestrictionVerify processor(&rSearchNode);
 			pNode->ParseChildren(processor);
@@ -157,7 +157,7 @@ RestrictionVerify::ProcessChoice(const XSD::Elements::Choice* pNode) {
 /* virtual */ void 
 RestrictionVerify::ProcessGroup(const XSD::Elements::Group* pNode) {
 	/* search for either a xs:group and verify that it is in the sub-tree */
-	bool bFound = m_pSubTree->_findChild([&](const Node& rSearchNode) -> bool {
+	bool bFound = m_pSubTree->findChild_([&](const Node& rSearchNode) -> bool {
 		if (XSD_ISELEMENT(&rSearchNode, Group)) {
 			const Group * pGroup = static_cast<const Group *>(&rSearchNode);
 			if (pNode->HasRef() && pGroup->HasName()) {
@@ -176,7 +176,7 @@ RestrictionVerify::ProcessGroup(const XSD::Elements::Group* pNode) {
 /* virtual */ void 
 RestrictionVerify::ProcessAll(const XSD::Elements::All* pNode) {
 	/* valid restrictions are xs:all to xs:all or xs:all to xs:sequence  */
-	bool bFound = m_pSubTree->_findChild([&](const Node& rSearchNode) -> bool {
+	bool bFound = m_pSubTree->findChild_([&](const Node& rSearchNode) -> bool {
 		if (XSD_ISELEMENT(&rSearchNode, All) ||
 			XSD_ISELEMENT(&rSearchNode, Sequence)) {
 			RestrictionVerify processor(&rSearchNode);

--- a/src/Processors/SimpleTypeExtracter.cpp
+++ b/src/Processors/SimpleTypeExtracter.cpp
@@ -48,7 +48,7 @@ SimpleTypeExtracter::~SimpleTypeExtracter() {
 
 const XSD::Types::BaseType&
 SimpleTypeExtracter::Extract(const XSD::Types::BaseType& rXSDType) {
-	_parseType(rXSDType);
+	parseType_(rXSDType);
 	return *m_pType;
 }
 
@@ -63,7 +63,7 @@ SimpleTypeExtracter::ProcessRestriction(const XSD::Elements::Restriction* pNode 
 		pNode->ParseChildren(*this);
 	else {
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Base());
-		_parseType(*pType);
+		parseType_(*pType);
 	}
 }
 
@@ -72,7 +72,7 @@ SimpleTypeExtracter::ProcessList(const XSD::Elements::List* pNode) {
 	unique_ptr<XSD::Types::BaseType> pTypeLst(pNode->ItemType());
 	/* extract xsd native type from simple type */
 	SimpleTypeExtracter typeXtr;
-	_parseType(Types::ArrayType(typeXtr.Extract(*pTypeLst)));
+	parseType_(Types::ArrayType(typeXtr.Extract(*pTypeLst)));
 }
 
 /* virtual */ void
@@ -82,7 +82,7 @@ SimpleTypeExtracter::ProcessInclude(const XSD::Elements::Include* pNode) {
 }
 
 void 
-SimpleTypeExtracter::_parseType(const XSD::Types::BaseType& rXSDType) {
+SimpleTypeExtracter::parseType_(const XSD::Types::BaseType& rXSDType) {
 	if(XSD_ISTYPE(&rXSDType, XSD::Types::SimpleType)) {
 		const XSD::Types::SimpleType* pSimpleType = static_cast<const XSD::Types::SimpleType*>(&rXSDType);
 		pSimpleType->m_pValue->ParseElement(*this);

--- a/src/Processors/SimpleTypeExtracter.hpp
+++ b/src/Processors/SimpleTypeExtracter.hpp
@@ -40,7 +40,7 @@ namespace Processors {
 		virtual void ProcessInclude(const XSD::Elements::Include* pNode);
 	private:
 		XSD::Types::BaseType* m_pType;
-		void _parseType(const XSD::Types::BaseType& rXSDType);
+		void parseType_(const XSD::Types::BaseType& rXSDType);
 	};
 }
 #endif /* SIMPLETYPEEXTRACTER_HPP_ */

--- a/src/XSDParser/Elements/All.cpp
+++ b/src/XSDParser/Elements/All.cpp
@@ -71,12 +71,6 @@ All::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessAll(this);
 }
 
-Types::BaseType * 
-All::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 int
 All::MaxOccurs() const {
 	if (HasMaxOccurs())

--- a/src/XSDParser/Elements/All.hpp
+++ b/src/XSDParser/Elements/All.hpp
@@ -37,7 +37,6 @@ namespace XSD {
 			All(const All& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			int MaxOccurs() const;
 			int MinOccurs() const;
 			bool HasMaxOccurs() const;

--- a/src/XSDParser/Elements/Annotation.cpp
+++ b/src/XSDParser/Elements/Annotation.cpp
@@ -60,8 +60,3 @@ Annotation::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessAnnotation(this);
 }
 
-Types::BaseType * 
-Annotation::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}

--- a/src/XSDParser/Elements/Annotation.hpp
+++ b/src/XSDParser/Elements/Annotation.hpp
@@ -39,7 +39,6 @@ namespace XSD {
 			Annotation(const Annotation& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Any.cpp
+++ b/src/XSDParser/Elements/Any.cpp
@@ -69,12 +69,6 @@ Any::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessAny(this);
 }
 
-Types::BaseType * 
-Any::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 Processors::ElementExtracter::ElementLst
 Any::GetAllowedElements() const {
   Processors::ElementExtracter::ElementLst retLst;
@@ -83,7 +77,7 @@ Any::GetAllowedElements() const {
 		std::unique_ptr<Schema> pDocRoot(Node::GetSchema());
 		retLst = elmExtrctr.Extract(*pDocRoot);
 		/* find parent element and remove it from list to prevent recursive loops */
-		std::unique_ptr<Element> pElement(_findParentElement(this));
+		std::unique_ptr<Element> pElement(findParentElement_(this));
 		if (NULL != pElement.get()) {
 			for (	Processors::ElementExtracter::ElementLst::iterator itr = retLst.begin();
 				  itr != retLst.end();
@@ -100,21 +94,12 @@ Any::GetAllowedElements() const {
 
 int
 Any::MaxOccurs() const {
-	if (HasMaxOccurs()) {
-		if (strcmp(Node::GetAttribute<const char*>("maxOccurs"), "unbounded"))
-			return Node::GetAttribute<int>("maxOccurs");
-		else
-			return -1;
-	}
-	return 1;
+	return Node::maxOccurs_(1);
 }
 
 int
 Any::MinOccurs() const {
-	if (HasMinOccurs()) {
-		return Node::GetAttribute<int>("minOccurs");
-	}
-	return 1;
+	return Node::minOccurs_(1);
 }
 
 std::string
@@ -162,11 +147,11 @@ Any::HasProcessContents() const {
 }
 
 /* static */ Element * 
-Any::_findParentElement(const Node * pNode) {
+Any::findParentElement_(const Node * pNode) {
 	if (NULL == pNode)
 		return NULL;
 	if (XSD_ISELEMENT(pNode, Element)) 
 		return new Element(*(static_cast<const Element *>(pNode)));
 	std::unique_ptr<Node> pParent(pNode->Parent());
-	return _findParentElement(pParent.get());
+	return findParentElement_(pParent.get());
 }

--- a/src/XSDParser/Elements/Any.hpp
+++ b/src/XSDParser/Elements/Any.hpp
@@ -36,7 +36,7 @@ namespace XSD {
 			XSD_ELEMENT_TAG("any")
 		private:
 			Any();
-			static Element * _findParentElement(const Node * pNode);
+			static Element * findParentElement_(const Node * pNode);
 		public:
 			typedef enum {
 				STRICT,
@@ -47,7 +47,6 @@ namespace XSD {
 			Any(const Any& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			Processors::ElementExtracter::ElementLst GetAllowedElements() const;
 			int MaxOccurs() const;
 			int MinOccurs() const;

--- a/src/XSDParser/Elements/AppInfo.cpp
+++ b/src/XSDParser/Elements/AppInfo.cpp
@@ -51,8 +51,3 @@ AppInfo::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessAppInfo(this);
 }
 
-Types::BaseType * 
-AppInfo::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}

--- a/src/XSDParser/Elements/AppInfo.hpp
+++ b/src/XSDParser/Elements/AppInfo.hpp
@@ -39,7 +39,6 @@ namespace XSD {
 			AppInfo(const AppInfo& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Attribute.cpp
+++ b/src/XSDParser/Elements/Attribute.cpp
@@ -47,7 +47,7 @@ Attribute::Attribute(const Attribute& rAttrib)
 void
 Attribute::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, SimpleType) ||
 			XSD_ISELEMENT(&rNode, Annotation)) {
 			rProcessor.ProcessSimpleType(static_cast<const SimpleType*>(&rNode));
@@ -88,15 +88,9 @@ Attribute::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	}
 }
 
-Types::BaseType * 
-Attribute::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 std::string
 Attribute::Name() const noexcept(false) {
-	return std::string(Node::GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 Attribute*
@@ -108,9 +102,9 @@ Types::BaseType*
 Attribute::Type() const noexcept(false) {
 	if (HasRef()) {
 		std::unique_ptr<XSD::Elements::Attribute> pRefAttrib(RefAttribute());
-		return _parseType(*pRefAttrib);
+		return parseType_(*pRefAttrib);
 	} else {
-		return _parseType(*this);
+		return parseType_(*this);
 	}
 }
 
@@ -171,7 +165,7 @@ Attribute::HasUse() const {
 }
 			
 Types::BaseType*
-Attribute::_type() const noexcept(false) {
+Attribute::type_() const noexcept(false) {
 	Types::BaseType* pType = Node::GetAttribute<Types::BaseType*>("type");
 	if (XSD_ISTYPE(pType, Types::Unknown)) {
 		delete pType;
@@ -183,9 +177,9 @@ Attribute::_type() const noexcept(false) {
 }
 
 /* static */ Types::BaseType*
-Attribute::_parseType(const Attribute& rAttrib) noexcept(false) {
+Attribute::parseType_(const Attribute& rAttrib) noexcept(false) {
 	if (rAttrib.HasContent(SimpleType::XSDTag()))
 		return new Types::SimpleType(rAttrib.FindXSDChildElm<SimpleType>());
 	else
-		return rAttrib._type();
+		return rAttrib.type_();
 }

--- a/src/XSDParser/Elements/Attribute.hpp
+++ b/src/XSDParser/Elements/Attribute.hpp
@@ -37,8 +37,8 @@ namespace XSD {
 			XSD_ELEMENT_TAG("attribute")
 		private:
 			Attribute();
-			Types::BaseType* _type() const noexcept(false);;
-			static Types::BaseType* _parseType(const Attribute& rAttrib) noexcept(false);;
+			Types::BaseType* type_() const noexcept(false);;
+			static Types::BaseType* parseType_(const Attribute& rAttrib) noexcept(false);;
 		public:
 			typedef enum {
 				OPTIONAL,
@@ -49,7 +49,6 @@ namespace XSD {
 			Attribute(const Attribute& rAttrib);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			std::string Name() const noexcept(false);;
 			Attribute* RefAttribute() const noexcept(false);;
 			Types::BaseType* Type() const noexcept(false);;

--- a/src/XSDParser/Elements/AttributeGroup.cpp
+++ b/src/XSDParser/Elements/AttributeGroup.cpp
@@ -43,7 +43,7 @@ AttributeGroup::AttributeGroup(const AttributeGroup& cpy)
 void
 AttributeGroup::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Attribute) ||
 			XSD_ISELEMENT(&rNode, Annotation)) {
 			rNode.ParseElement(rProcessor);
@@ -71,15 +71,9 @@ AttributeGroup::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessAttributeGroup(this);
 }
 
-Types::BaseType * 
-AttributeGroup::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 std::string
 AttributeGroup::Name() const noexcept(false) {
-	return std::string(Node::GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 AttributeGroup*

--- a/src/XSDParser/Elements/AttributeGroup.hpp
+++ b/src/XSDParser/Elements/AttributeGroup.hpp
@@ -39,7 +39,6 @@ namespace XSD {
 			AttributeGroup(const AttributeGroup& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			std::string Name() const noexcept(false);;
 			AttributeGroup* RefGroup() const noexcept(false);;
 			bool HasName() const;

--- a/src/XSDParser/Elements/Choice.cpp
+++ b/src/XSDParser/Elements/Choice.cpp
@@ -47,7 +47,7 @@ Choice::Choice(const Choice& rCpy)
 void
 Choice::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Element) ||
 			XSD_ISELEMENT(&rNode, Choice) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
@@ -71,29 +71,14 @@ Choice::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessChoice(this);
 }
 
-Types::BaseType * 
-Choice::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 int
 Choice::MaxOccurs() const {
-	if (HasMaxOccurs()) {
-		if (strcmp(Node::GetAttribute<const char*>("maxOccurs"), "unbounded"))
-			return Node::GetAttribute<int>("maxOccurs");
-		else
-			return -1;
-	}
-	return 1;
+	return Node::maxOccurs_(1);
 }
 
 int
 Choice::MinOccurs() const {
-	if (HasMinOccurs()) {
-		return Node::GetAttribute<int>("minOccurs");
-	}
-	return 1;
+	return Node::minOccurs_(1);
 }
 
 bool

--- a/src/XSDParser/Elements/Choice.hpp
+++ b/src/XSDParser/Elements/Choice.hpp
@@ -42,7 +42,6 @@ namespace XSD {
 			Choice(const Choice& rCpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			int MaxOccurs() const;
 			int MinOccurs() const;
 			bool HasElements() const noexcept(false);;

--- a/src/XSDParser/Elements/ComplexContent.cpp
+++ b/src/XSDParser/Elements/ComplexContent.cpp
@@ -49,7 +49,7 @@ ComplexContent::ComplexContent(const ComplexContent& rType)
 void
 ComplexContent::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Restriction) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Extension)) {
@@ -64,16 +64,9 @@ ComplexContent::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessComplexContent(this);
 }
 
-Types::BaseType * 
+Types::BaseType *
 ComplexContent::GetParentType() const noexcept(false) {
-	std::unique_ptr<Restriction> pRestriction(Node::SearchXSDChildElm<Restriction>());
-	std::unique_ptr<Extension> pExtension(Node::SearchXSDChildElm<Extension>());
-	if ((NULL != pRestriction.get()) && (NULL == pExtension.get())) {
-		return pRestriction->GetParentType();
-	} else if ((NULL == pRestriction.get()) && (NULL != pExtension.get())) {
-		return pExtension->GetParentType();
-	} else /* complex content can't have multiple child modifiers */
-		throw XMLException(Node::GetXMLElm(), XMLException::InvallidChildXMLElement);
+	return Node::delegateToSoleChild_();
 }
 
 bool

--- a/src/XSDParser/Elements/ComplexType.cpp
+++ b/src/XSDParser/Elements/ComplexType.cpp
@@ -57,7 +57,7 @@ ComplexType::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
 	enum { CMODEL_UNKNOWN, CMODEL_TRUE, CMODEL_FALSE };
 	int contentModel = CMODEL_UNKNOWN;
-	_eachChild([&rProcessor, &contentModel](const Node& rNode) {
+	eachChild_([&rProcessor, &contentModel](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, ComplexContent) ||
 			XSD_ISELEMENT(&rNode, SimpleContent)) {
 			if (CMODEL_FALSE != contentModel) {
@@ -125,7 +125,7 @@ ComplexType::Mixed() const {
 
 std::string
 ComplexType::Name() const noexcept(false) {
-	return std::string(Node::GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 bool

--- a/src/XSDParser/Elements/Documentation.cpp
+++ b/src/XSDParser/Elements/Documentation.cpp
@@ -55,12 +55,6 @@ Documentation::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessDocumentation(this);
 }
 
-Types::BaseType * 
-Documentation::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 std::string
 Documentation::DocumentationStr() const noexcept(false) {
 	if (Node::HasContent()) {

--- a/src/XSDParser/Elements/Documentation.hpp
+++ b/src/XSDParser/Elements/Documentation.hpp
@@ -39,7 +39,6 @@ namespace XSD {
 			Documentation(const Documentation& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			std::string DocumentationStr() const noexcept(false);;
 		};
 	}	/* namespace Elements */

--- a/src/XSDParser/Elements/Element.cpp
+++ b/src/XSDParser/Elements/Element.cpp
@@ -48,7 +48,7 @@ Element::Element(const Element& elm)
 void
 Element::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, SimpleType) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, ComplexType)) {
@@ -109,7 +109,7 @@ Element::Abstract() const {
 
 std::string
 Element::Name() const noexcept(false) {
-	return std::string(Node::GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 Element*
@@ -129,9 +129,9 @@ Types::BaseType*
 Element::Type() const noexcept(false) {
 	if (HasRef()) {
 		std::unique_ptr<XSD::Elements::Element> pRefElm(RefElement());
-		return _ParseType(*pRefElm.get());
+		return ParseType_(*pRefElm.get());
 	} else {
-		return _ParseType(*this);
+		return ParseType_(*this);
 	}
 }
 
@@ -189,7 +189,7 @@ Element::HasMinOccurs() const {
 }
 
 Types::BaseType*
-Element::_Type() const noexcept(false) {
+Element::Type_() const noexcept(false) {
 	Types::BaseType* pRetType = Node::GetAttribute<Types::BaseType*>("type");
 	if (XSD_ISTYPE(pRetType, Types::Unknown)) {
 		delete pRetType;
@@ -200,7 +200,7 @@ Element::_Type() const noexcept(false) {
 }
 
 /* static */ Types::BaseType*
-Element::_ParseType(const Element& rElm) noexcept(false) {
+Element::ParseType_(const Element& rElm) noexcept(false) {
 	if (rElm.HasChildType() &&
 		(rElm.HasContent(SimpleType::XSDTag()) || rElm.HasContent(ComplexType::XSDTag()))) {
 		if (rElm.HasContent(SimpleType::XSDTag())) {
@@ -209,10 +209,10 @@ Element::_ParseType(const Element& rElm) noexcept(false) {
 			return new Types::ComplexType(rElm.FindXSDChildElm<ComplexType>());
 		}
 	} else if (rElm.HasType()) {
-		return rElm._Type();
+		return rElm.Type_();
 	} else if (rElm.HasSubstitutionGroup()) {
 		std::unique_ptr<Element> pElm(rElm.SubstitutionGroup());
-		return _ParseType(*(pElm.get()));
+		return ParseType_(*(pElm.get()));
 	} else {
 		return new Types::String();
 	}

--- a/src/XSDParser/Elements/Element.hpp
+++ b/src/XSDParser/Elements/Element.hpp
@@ -37,8 +37,8 @@ namespace XSD {
 			XSD_ELEMENT_TAG("element")
 		private:
 			Element();
-			Types::BaseType* _Type() const noexcept(false);;
-			static Types::BaseType* _ParseType(const Element& rElm) noexcept(false);;
+			Types::BaseType* Type_() const noexcept(false);;
+			static Types::BaseType* ParseType_(const Element& rElm) noexcept(false);;
 		public:
 			Element(const TiXmlElement& elm, const Parser& rParser);
 			Element( const Element& elm);

--- a/src/XSDParser/Elements/Enumeration.cpp
+++ b/src/XSDParser/Elements/Enumeration.cpp
@@ -35,11 +35,11 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 Enumeration::Enumeration(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 Enumeration::Enumeration(const Enumeration& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
 
 void
@@ -59,18 +59,7 @@ Enumeration::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessEnumeration(this);
 }
 
-Types::BaseType * 
-Enumeration::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 std::string
 Enumeration::Value() const noexcept(false) {
 	return std::string(Node::GetAttribute<const char*>("value"));
-}
-
-bool
-Enumeration::HasValue() const {
-	return Node::HasAttribute("value");
 }

--- a/src/XSDParser/Elements/Enumeration.hpp
+++ b/src/XSDParser/Elements/Enumeration.hpp
@@ -28,20 +28,20 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class Enumeration : public Node {
+		class Enumeration
+				: public FacetNode<Enumeration, std::string> {
 			XSD_ELEMENT_TAG("enumeration")
 		private:
 			Enumeration();
 		public:
 			Enumeration(const TiXmlElement& elm, const Parser& rParser);
 			Enumeration(const Enumeration& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			std::string Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
+			std::string Value() const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Extension.cpp
+++ b/src/XSDParser/Elements/Extension.cpp
@@ -53,7 +53,7 @@ void
 Extension::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	if (isParentComplex()) {
 		/* process children */
-		_eachChild([&rProcessor](const Node& rNode) {
+		eachChild_([&rProcessor](const Node& rNode) {
 			if (XSD_ISELEMENT(&rNode, Group) ||
 				XSD_ISELEMENT(&rNode, Choice) ||
 				XSD_ISELEMENT(&rNode, Sequence) ||
@@ -66,7 +66,7 @@ Extension::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 		});
 	} else {
 		/* process children */
-		_eachChild([&rProcessor](const Node& rNode) {
+		eachChild_([&rProcessor](const Node& rNode) {
 			if (XSD_ISELEMENT(&rNode, Attribute) ||
 				XSD_ISELEMENT(&rNode, Annotation)) {
 				rNode.ParseElement(rProcessor);
@@ -85,12 +85,12 @@ Extension::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	std::unique_ptr<Types::BaseType> pBase(Base());
 	if (XSD_ISTYPE(pBase.get(),Types::SimpleType)) {
 		const Types::SimpleType* pSmplType = static_cast<const Types::SimpleType*>(pBase.get());
-		if (_checkForDuplicateNamedParticles(&Node::GetXMLElm(), &pSmplType->m_pValue->GetXMLElm())) {
+		if (checkForDuplicateNamedParticles_(&Node::GetXMLElm(), &pSmplType->m_pValue->GetXMLElm())) {
 			throw XMLException(GetXMLElm(), XMLException::InvallidChildXMLElement);
 		}
 	} else if (XSD_ISTYPE(pBase.get(),Types::ComplexType)) {
 		const Types::ComplexType* pCmplxType = static_cast<const Types::ComplexType*>(pBase.get());
-		if (_checkForDuplicateNamedParticles(&Node::GetXMLElm(), &pCmplxType->m_pValue->GetXMLElm())) {
+		if (checkForDuplicateNamedParticles_(&Node::GetXMLElm(), &pCmplxType->m_pValue->GetXMLElm())) {
 			throw XMLException(GetXMLElm(), XMLException::InvallidChildXMLElement);
 		}
 	}
@@ -104,7 +104,7 @@ Extension::GetParentType(void) const noexcept(false) {
 
 Types::BaseType*
 Extension::Base() const noexcept(false) {
-	return Node::GetAttribute<Types::BaseType*>("base");
+	return Node::baseType_();
 }
 
 bool
@@ -114,22 +114,22 @@ Extension::isParentComplex() const noexcept(false) {
 }
 
 /* static */ bool
-Extension::_checkForDuplicateNamedParticles(const TiXmlElement* pTreeBase, const TiXmlElement* pBase) {
+Extension::checkForDuplicateNamedParticles_(const TiXmlElement* pTreeBase, const TiXmlElement* pBase) {
 	const TiXmlElement* pChld = pTreeBase->FirstChildElement();
 	for (; pChld ; pChld = pChld->NextSiblingElement()) {
 		/* check to see if element has a name attribute */
 		if (NULL != pChld->Attribute("name")) {
-			return _find(pChld->Attribute("name"), pBase);
+			return find_(pChld->Attribute("name"), pBase);
 		}
 		/* search children */
-		if (true ==_checkForDuplicateNamedParticles(pChld, pBase))
+		if (true ==checkForDuplicateNamedParticles_(pChld, pBase))
 			return true;
 	}
 	return false;
 }
 
 /* static */ bool
-Extension::_find(const char* pName, const TiXmlElement* pBase) {
+Extension::find_(const char* pName, const TiXmlElement* pBase) {
 	const TiXmlElement* pChld = pBase->FirstChildElement();
 	for (; pChld ; pChld = pChld->NextSiblingElement()) {
 		/* check to see if element has a name attribute */
@@ -139,7 +139,7 @@ Extension::_find(const char* pName, const TiXmlElement* pBase) {
 			}
 		}
 		/* search children */
-		if (true == _find(pName, pChld))
+		if (true == find_(pName, pChld))
 			return true;
 	}
 	return false;

--- a/src/XSDParser/Elements/Extension.hpp
+++ b/src/XSDParser/Elements/Extension.hpp
@@ -36,8 +36,8 @@ namespace XSD {
 			XSD_ELEMENT_TAG("extension")
 		private:
 			Extension();
-			static bool _checkForDuplicateNamedParticles(const TiXmlElement* pTreeBase, const TiXmlElement* pBase);
-			static bool _find(const char* pName, const TiXmlElement* pBase);
+			static bool checkForDuplicateNamedParticles_(const TiXmlElement* pTreeBase, const TiXmlElement* pBase);
+			static bool find_(const char* pName, const TiXmlElement* pBase);
 		public:
 			Extension(const TiXmlElement& elm, const Parser& rParser);
 			Extension(const Extension& rType);

--- a/src/XSDParser/Elements/FacetNode.hpp
+++ b/src/XSDParser/Elements/FacetNode.hpp
@@ -1,0 +1,73 @@
+/*
+ * FacetNode.hpp
+ *
+ *  Created on: Jun 25, 2011
+ *      Author: QVXLabs LLC
+ *   Copyright: (c)2011 QVXLabs LLC
+ *
+ *  This file is part of xsd-tools.
+ *
+ *  xsd-tools is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  xsd-tools is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FACETNODE_HPP_
+#define FACETNODE_HPP_
+
+#ifndef TIXML_USE_STL
+#	define TIXML_USE_STL
+#endif /* TIXML_USE_STL */
+#include <memory>
+#include <tinyxml.h>
+#include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/Annotation.hpp"
+
+namespace XSD {
+	namespace Elements {
+		/* CRTP base shared by the leaf facet classes. Holds the parts that
+		 * are byte-identical across all facets; subclasses keep only their tag,
+		 * ParseElement dispatch, and any value-type override. ValueT selects
+		 * the numeric Value() return type. */
+		template<typename Derived, typename ValueT>
+		class FacetNode : public Node {
+		protected:
+			FacetNode(const TiXmlElement& elm, const Parser& rParser)
+				: Node(elm, rParser)
+			{ }
+			FacetNode(const Derived& cpy)
+				: Node(cpy)
+			{ }
+		public:
+			void ParseChildren(BaseProcessor& rProcessor)
+					const noexcept(false) {
+				/* no children allowed */
+				std::unique_ptr<Node> pNode(Node::FirstChild());
+				if (NULL != pNode.get()) {
+					if (XSD_ISELEMENT(pNode.get(), Annotation))
+						pNode->ParseElement(rProcessor);
+					else
+						throw XMLException(pNode->GetXMLElm(),
+							XMLException::InvallidChildXMLElement);
+				}
+			}
+			ValueT Value() const noexcept(false) {
+				return Node::GetAttribute<ValueT>("value");
+			}
+			bool HasValue() const {
+				return Node::HasAttribute("value");
+			}
+		};
+	}	/* namespace Elements */
+}	/* namespace XSD */
+
+#endif /* FACETNODE_HPP_ */

--- a/src/XSDParser/Elements/FractionDigits.cpp
+++ b/src/XSDParser/Elements/FractionDigits.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 FractionDigits::FractionDigits(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 FractionDigits::FractionDigits(const FractionDigits& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-FractionDigits::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 FractionDigits::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessFractionDigits(this);
 }
 
-Types::BaseType * 
-FractionDigits::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-uint64_t
-FractionDigits::Value() const noexcept(false) {
-	return Node::GetAttribute<uint64_t>("value");
-}
-
-bool
-FractionDigits::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/FractionDigits.hpp
+++ b/src/XSDParser/Elements/FractionDigits.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class FractionDigits : public Node {
+		class FractionDigits
+				: public FacetNode<FractionDigits, uint64_t> {
 			XSD_ELEMENT_TAG("fractionDigits")
 		private:
 			FractionDigits();
 		public:
 			FractionDigits(const TiXmlElement& elm, const Parser& rParser);
 			FractionDigits(const FractionDigits& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			uint64_t Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Group.cpp
+++ b/src/XSDParser/Elements/Group.cpp
@@ -48,7 +48,7 @@ Group::Group(const Group& cpy)
 void
 Group::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Choice) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, All) ||
@@ -85,34 +85,19 @@ Group::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessGroup(this);
 }
 
-Types::BaseType * 
-Group::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 int
 Group::MaxOccurs() const {
-	if (HasMaxOccurs()) {
-		if (strcmp(Node::GetAttribute<const char*>("maxOccurs"), "unbounded"))
-			return Node::GetAttribute<int>("maxOccurs");
-		else
-			return -1;
-	}
-	return 1;
+	return Node::maxOccurs_(1);
 }
 
 int
 Group::MinOccurs() const {
-	if (HasMinOccurs()) {
-		return Node::GetAttribute<int>("minOccurs");
-	}
-	return 1;
+	return Node::minOccurs_(1);
 }
 
 std::string
 Group::Name() const noexcept(false) {
-	return std::string(Node::GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 Group*

--- a/src/XSDParser/Elements/Group.hpp
+++ b/src/XSDParser/Elements/Group.hpp
@@ -39,7 +39,6 @@ namespace XSD {
 			Group(const Group& cpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			int MaxOccurs() const;
 			int MinOccurs() const;
 			std::string Name() const noexcept(false);;

--- a/src/XSDParser/Elements/Include.cpp
+++ b/src/XSDParser/Elements/Include.cpp
@@ -56,16 +56,10 @@ Include::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessInclude(this);
 }
 
-Types::BaseType * 
-Include::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 const Schema*
 Include::QuerySchema() const noexcept(false) {
 	if (NULL == m_pSchema) {
-		m_pSchema = Node::GetParser().Parse(_schemaURI());
+		m_pSchema = Node::GetParser().Parse(schemaURI_());
 	}
 	return m_pSchema;
 }
@@ -76,23 +70,23 @@ Include::HasSchema() const {
 }
 
 std::string
-Include::_schemaURI() const noexcept(false) {
+Include::schemaURI_() const noexcept(false) {
 	std::string uri(Node::GetAttribute<const char*>("schemaLocation"));
 	/* handle file URIs differently */
-	if (_isFileURI(uri)) {
+	if (isFileURI_(uri)) {
 		std::string retStr("file://");
-		boost::filesystem::path path(_extractURIPath(uri));
+		boost::filesystem::path path(extractURIPath_(uri));
 		if (path.has_root_path()) {
-			retStr += (path.string() + _extractQuery(uri));
+			retStr += (path.string() + extractQuery_(uri));
 			return retStr;
 		} else {
 			std::unique_ptr<Schema> pDocRoot(Node::GetSchema());
 #if defined(BOOST_FILESYSTEM_VERSION) && (BOOST_FILESYSTEM_VERSION > 2)
-			boost::filesystem::path schemaPath = (boost::filesystem::absolute(_extractURIPath(pDocRoot->URI()))).branch_path();
+			boost::filesystem::path schemaPath = (boost::filesystem::absolute(extractURIPath_(pDocRoot->URI()))).branch_path();
 #else
-			boost::filesystem::path schemaPath = (boost::filesystem::complete(_extractURIPath(pDocRoot->URI()))).branch_path();
+			boost::filesystem::path schemaPath = (boost::filesystem::complete(extractURIPath_(pDocRoot->URI()))).branch_path();
 #endif
-			(schemaPath /= _extractURIPath(uri)).normalize();
+			(schemaPath /= extractURIPath_(uri)).normalize();
 			retStr += schemaPath.string();
 			return retStr;
 		}
@@ -102,7 +96,7 @@ Include::_schemaURI() const noexcept(false) {
 }
 
 /* static */std::string
-Include::_extractURIPath(const std::string& uri) {
+Include::extractURIPath_(const std::string& uri) {
 	/* strip off query section */
 	std::string noQuery		= uri.substr(0, uri.find("?"));
 	/* strip off protocol section */
@@ -112,7 +106,7 @@ Include::_extractURIPath(const std::string& uri) {
 }
 
 /* static */ bool
-Include::_isFileURI(const std::string& uri) {
+Include::isFileURI_(const std::string& uri) {
 	/* strip off query section */
 	std::string noQuery	= uri.substr(0, uri.find("?"));
 	bool hasFileProto	= (std::string::npos != noQuery.find("file://"));
@@ -121,7 +115,7 @@ Include::_isFileURI(const std::string& uri) {
 }
 
 /* static */ std::string
-Include::_extractQuery(const std::string& uri) {
+Include::extractQuery_(const std::string& uri) {
 	const size_t queryNdx = uri.find("?");
 	if (std::string::npos == queryNdx)
 		return std::string("");

--- a/src/XSDParser/Elements/Include.hpp
+++ b/src/XSDParser/Elements/Include.hpp
@@ -28,7 +28,6 @@
 #endif /* TIXML_USE_STL */
 #include <string>
 #include <tinyxml.h>
-#include "./src/XSDParser/Exception.hpp"
 #include "./src/XSDParser/Elements/Node.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"
 
@@ -38,19 +37,17 @@ namespace XSD {
 			XSD_ELEMENT_TAG("include")
 		private:
 			mutable Schema*	m_pSchema;
-			Parser	m_parser;
 			Include();
-			std::string _schemaURI() const noexcept(false);;
-			static std::string _extractURIPath(const std::string& uri);
-			static bool _isFileURI(const std::string& uri);
-			static std::string _extractQuery(const std::string& uri);
+			std::string schemaURI_() const noexcept(false);;
+			static std::string extractURIPath_(const std::string& uri);
+			static bool isFileURI_(const std::string& uri);
+			static std::string extractQuery_(const std::string& uri);
 		public:
 			Include(const TiXmlElement& elm, const Parser& rParser);
 			Include(const Include& elm);
 			virtual ~Include();
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			const Schema* QuerySchema() const noexcept(false);;
 			bool HasSchema() const;
 		};

--- a/src/XSDParser/Elements/Length.cpp
+++ b/src/XSDParser/Elements/Length.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 Length::Length(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 Length::Length(const Length& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-Length::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 Length::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessLength(this);
 }
 
-Types::BaseType * 
-Length::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-int64_t
-Length::Value() const noexcept(false) {
-	return Node::GetAttribute<int64_t>("value");
-}
-
-bool
-Length::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/Length.hpp
+++ b/src/XSDParser/Elements/Length.hpp
@@ -30,20 +30,18 @@
 #include <tinyxml.h>
 #include <stdint.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class Length : public Node {
+		class Length
+				: public FacetNode<Length, int64_t> {
 			XSD_ELEMENT_TAG("length")
 		private:
 			Length();
 		public:
 			Length(const TiXmlElement& elm, const Parser& rParser);
 			Length(const Length& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			int64_t Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/List.cpp
+++ b/src/XSDParser/Elements/List.cpp
@@ -44,7 +44,7 @@ List::List(const List& lst)
 void
 List::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, SimpleType) ||
 			XSD_ISELEMENT(&rNode, Annotation)) {
 			rNode.ParseElement(rProcessor);
@@ -81,11 +81,11 @@ List::ItemType() const noexcept(false) {
 	if (HasContent(SimpleType::XSDTag()))
 		return new Types::SimpleType(FindXSDChildElm<SimpleType>());
 	else
-		return _type();
+		return type_();
 };
 
 Types::BaseType*
-List::_type() const noexcept(false) {
+List::type_() const noexcept(false) {
 	Types::BaseType* pType = Node::GetAttribute<Types::BaseType*>("itemType");
 	if (XSD_ISTYPE(pType, Types::Unknown)) {
 		delete pType;

--- a/src/XSDParser/Elements/List.hpp
+++ b/src/XSDParser/Elements/List.hpp
@@ -34,7 +34,7 @@ namespace XSD {
 			XSD_ELEMENT_TAG("list")
 		private:
 			List();
-			Types::BaseType* _type() const noexcept(false);;
+			Types::BaseType* type_() const noexcept(false);;
 		public:
 			List(const TiXmlElement& elm, const Parser& rParser);
 			List(const List& lst);

--- a/src/XSDParser/Elements/MaxExclusive.cpp
+++ b/src/XSDParser/Elements/MaxExclusive.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MaxExclusive::MaxExclusive(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MaxExclusive::MaxExclusive(const MaxExclusive& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MaxExclusive::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MaxExclusive::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMaxExclusive(this);
 }
 
-Types::BaseType * 
-MaxExclusive::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-long double
-MaxExclusive::Value() const noexcept(false) {
-	return Node::GetAttribute<long double>("value");
-}
-
-bool
-MaxExclusive::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/MaxExclusive.hpp
+++ b/src/XSDParser/Elements/MaxExclusive.hpp
@@ -25,20 +25,18 @@
 #define MAXEXCLUSIVE_HPP_
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MaxExclusive : public Node {
+		class MaxExclusive
+				: public FacetNode<MaxExclusive, long double> {
 			XSD_ELEMENT_TAG("maxExclusive")
 		private:
 			MaxExclusive();
 		public:
 			MaxExclusive(const TiXmlElement& elm, const Parser& rParser);
 			MaxExclusive(const MaxExclusive& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			long double Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/MaxInclusive.cpp
+++ b/src/XSDParser/Elements/MaxInclusive.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MaxInclusive::MaxInclusive(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MaxInclusive::MaxInclusive(const MaxInclusive& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MaxInclusive::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MaxInclusive::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMaxInclusive(this);
 }
 
-Types::BaseType * 
-MaxInclusive::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-long double
-MaxInclusive::Value() const noexcept(false) {
-	return Node::GetAttribute<long double>("value");
-}
-
-bool
-MaxInclusive::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/MaxInclusive.hpp
+++ b/src/XSDParser/Elements/MaxInclusive.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MaxInclusive : public Node {
+		class MaxInclusive
+				: public FacetNode<MaxInclusive, long double> {
 			XSD_ELEMENT_TAG("maxInclusive")
 		private:
 			MaxInclusive();
 		public:
 			MaxInclusive(const TiXmlElement& elm, const Parser& rParser);
 			MaxInclusive(const MaxInclusive& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			long double Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/MaxLength.cpp
+++ b/src/XSDParser/Elements/MaxLength.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MaxLength::MaxLength(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MaxLength::MaxLength(const MaxLength& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MaxLength::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MaxLength::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMaxLength(this);
 }
 
-Types::BaseType * 
-MaxLength::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-int64_t
-MaxLength::Value() const noexcept(false) {
-	return Node::GetAttribute<int64_t>("value");
-}
-
-bool
-MaxLength::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/MaxLength.hpp
+++ b/src/XSDParser/Elements/MaxLength.hpp
@@ -30,20 +30,18 @@
 #include <tinyxml.h>
 #include <stdint.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MaxLength : public Node {
+		class MaxLength
+				: public FacetNode<MaxLength, int64_t> {
 			XSD_ELEMENT_TAG("maxLength")
 		private:
 			MaxLength();
 		public:
 			MaxLength(const TiXmlElement& elm, const Parser& rParser);
 			MaxLength(const MaxLength& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			int64_t Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/MinExclusive.cpp
+++ b/src/XSDParser/Elements/MinExclusive.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MinExclusive::MinExclusive(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MinExclusive::MinExclusive(const MinExclusive& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MinExclusive::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MinExclusive::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMinExclusive(this);
 }
 
-Types::BaseType * 
-MinExclusive::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-long double
-MinExclusive::Value() const noexcept(false) {
-	return Node::GetAttribute<long double>("value");
-}
-
-bool
-MinExclusive::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/MinExclusive.hpp
+++ b/src/XSDParser/Elements/MinExclusive.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MinExclusive : public Node {
+		class MinExclusive
+				: public FacetNode<MinExclusive, long double> {
 			XSD_ELEMENT_TAG("minExclusive")
 		private:
 			MinExclusive();
 		public:
 			MinExclusive(const TiXmlElement& elm, const Parser& rParser);
 			MinExclusive(const MinExclusive& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
-			Types::BaseType * GetParentType() const noexcept(false);
-			long double Value() const noexcept(false);
-			bool HasValue() const;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/MinInclusive.cpp
+++ b/src/XSDParser/Elements/MinInclusive.cpp
@@ -35,42 +35,14 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MinInclusive::MinInclusive(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MinInclusive::MinInclusive(const MinInclusive& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MinInclusive::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MinInclusive::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMinInclusive(this);
-}
-
-Types::BaseType * 
-MinInclusive::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-long double
-MinInclusive::Value() const noexcept(false) {
-	return Node::GetAttribute<long double>("value");
-}
-
-bool
-MinInclusive::HasValue() const {
-	return Node::HasAttribute("value");
 }

--- a/src/XSDParser/Elements/MinInclusive.hpp
+++ b/src/XSDParser/Elements/MinInclusive.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MinInclusive : public Node {
+		class MinInclusive
+				: public FacetNode<MinInclusive, long double> {
 			XSD_ELEMENT_TAG("minInclusive")
 		private:
 			MinInclusive();
 		public:
 			MinInclusive(const TiXmlElement& elm, const Parser& rParser);
 			MinInclusive(const MinInclusive& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
-			Types::BaseType * GetParentType() const noexcept(false);
-			long double Value() const noexcept(false);
-			bool HasValue() const;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/MinLength.cpp
+++ b/src/XSDParser/Elements/MinLength.cpp
@@ -35,42 +35,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 MinLength::MinLength(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 MinLength::MinLength(const MinLength& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-MinLength::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 MinLength::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessMinLength(this);
 }
 
-Types::BaseType * 
-MinLength::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-int64_t
-MinLength::Value() const noexcept(false) {
-	return Node::GetAttribute<int64_t>("value");
-}
-
-bool
-MinLength::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/MinLength.hpp
+++ b/src/XSDParser/Elements/MinLength.hpp
@@ -30,20 +30,18 @@
 #include <tinyxml.h>
 #include <stdint.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class MinLength : public Node {
+		class MinLength
+				: public FacetNode<MinLength, int64_t> {
 			XSD_ELEMENT_TAG("minLength")
 		private:
 			MinLength();
 		public:
 			MinLength(const TiXmlElement& elm, const Parser& rParser);
 			MinLength(const MinLength& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			int64_t Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <memory>
+#include <string.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include "./src/XSDParser/Elements/Node.hpp"
 #include "./src/XSDParser/Elements/Attribute.hpp"
@@ -69,7 +70,7 @@ namespace XSD{
 		template<> bool
 		Node::GetAttribute<bool>(const char* pAttrib) const noexcept(false) {
 			bool retVal;
-			std::string attribStr(_Attribute(pAttrib));
+			std::string attribStr(Attribute_(pAttrib));
 			std::transform(attribStr.begin(), attribStr.end(), attribStr.begin(),::tolower);
 			std::stringstream sstrm(attribStr);
 			sstrm >> std::boolalpha >> retVal;
@@ -87,7 +88,7 @@ namespace XSD{
 		Node::GetAttribute<Types::BaseType*>(const char* pAttrib) const noexcept(false) {
 			const char* pTypeStr = GetAttribute<const char*>(pAttrib);
 			if (!pTypeStr) throw XMLException(m_rXmlElm, XMLException::MissingAttribute);
-			return _Type(pTypeStr);
+			return Type_(pTypeStr);
 		}
 	}
 }
@@ -126,7 +127,7 @@ Node::~Node() {
 }
 
 const TiXmlElement*
-Node::_FindChildXMLElement(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false) {
+Node::FindChildXMLElement_(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false) {
 	/* search all nodes in root document */
 	const TiXmlElement* pElm = m_rXmlElm.FirstChildElement(pXMLElmTag);
 	for ( ;
@@ -136,131 +137,171 @@ Node::_FindChildXMLElement(const char* pXMLElmTag, const char* pAttrib, const ch
 }
 
 Node*
-Node::_ConstructNode(const TiXmlElement* pElm, const Parser& rParser) const {
-	const std::string elementName = _StripNamespace(pElm->ValueStr());
-	if (boost::iequals(std::string(Attribute::XSDTag()), elementName)) {
-		return new Attribute(*pElm, rParser);
-	} else if (boost::iequals(std::string(Choice::XSDTag()), elementName)) {
-		return new Choice(*pElm, rParser);
-	} else if (boost::iequals(std::string(Element::XSDTag()), elementName)) {
-		return new Element(*pElm, rParser);
-	} else if (boost::iequals(std::string(List::XSDTag()), elementName)) {
-		return new List(*pElm, rParser);
-	} else if (boost::iequals(std::string(Restriction::XSDTag()), elementName)) {
-		return new Restriction(*pElm, rParser);
-	} else if (boost::iequals(std::string(Sequence::XSDTag()), elementName)) {
-		return new Sequence(*pElm, rParser);
-	} else if (boost::iequals(std::string(Union::XSDTag()), elementName)) {
-		return new Union(*pElm, rParser);
-	} else if (boost::iequals(std::string(Schema::XSDTag()), elementName)) {
-		return new Schema(*pElm, rParser, std::string(""));
-	} else if (boost::iequals(std::string(SimpleType::XSDTag()), elementName)) {
-		return new SimpleType(*pElm, rParser);
-	} else if (boost::iequals(std::string(ComplexType::XSDTag()), elementName)) {
-		return new ComplexType(*pElm, rParser);
-	} else if (boost::iequals(std::string(Group::XSDTag()), elementName)) {
-		return new Group(*pElm, rParser);
-	} else if (boost::iequals(std::string(Any::XSDTag()), elementName)) {
-		return new Any(*pElm, rParser);
-	} else if (boost::iequals(std::string(ComplexContent::XSDTag()), elementName)) {
-		return new ComplexContent(*pElm, rParser);
-	} else if (boost::iequals(std::string(Extension::XSDTag()), elementName)) {
-		return new Extension(*pElm, rParser);
-	} else if (boost::iequals(std::string(SimpleContent::XSDTag()), elementName)) {
-		return new SimpleContent(*pElm, rParser);
-	} else if (boost::iequals(std::string(MinExclusive::XSDTag()), elementName)) {
-		return new MinExclusive(*pElm, rParser);
-	} else if (boost::iequals(std::string(MaxExclusive::XSDTag()), elementName)) {
-		return new MaxExclusive(*pElm, rParser);
-	} else if (boost::iequals(std::string(MinInclusive::XSDTag()), elementName)) {
-		return new MinInclusive(*pElm, rParser);
-	} else if (boost::iequals(std::string(MaxInclusive::XSDTag()), elementName)) {
-		return new MaxInclusive(*pElm, rParser);
-	} else if (boost::iequals(std::string(MinLength::XSDTag()), elementName)) {
-		return new MinLength(*pElm, rParser);
-	} else if (boost::iequals(std::string(MaxLength::XSDTag()), elementName)) {
-		return new MaxLength(*pElm, rParser);
-	} else if (boost::iequals(std::string(Length::XSDTag()), elementName)) {
-		return new Length(*pElm, rParser);
-	} else if (boost::iequals(std::string(Enumeration::XSDTag()), elementName)) {
-		return new Enumeration(*pElm, rParser);
-	} else if (boost::iequals(std::string(FractionDigits::XSDTag()), elementName)) {
-		return new FractionDigits(*pElm, rParser);
-	} else if (boost::iequals(std::string(Pattern::XSDTag()), elementName)) {
-		return new Pattern(*pElm, rParser);
-	} else if (boost::iequals(std::string(TotalDigits::XSDTag()), elementName)) {
-		return new TotalDigits(*pElm, rParser);
-	} else if (boost::iequals(std::string(WhiteSpace::XSDTag()), elementName)) {
-		return new WhiteSpace(*pElm, rParser);
-	} else if (boost::iequals(std::string(AttributeGroup::XSDTag()), elementName)) {
-		return new AttributeGroup(*pElm, rParser);
-	} else if (boost::iequals(std::string(Include::XSDTag()), elementName)) {
-		return new Include(*pElm, rParser);
-	} else if (boost::iequals(std::string(Annotation::XSDTag()), elementName)) {
-		return new Annotation(*pElm, rParser);
-	} else if (boost::iequals(std::string(Documentation::XSDTag()), elementName)) {
-		return new Documentation(*pElm, rParser);
-	} else if (boost::iequals(std::string(All::XSDTag()), elementName)) {
-		return new All(*pElm, rParser);
-	} else if (boost::iequals(std::string(AppInfo::XSDTag()), elementName)) {
-		return new AppInfo(*pElm, rParser);
-	} else
-		throw XMLException(*pElm, XMLException::InvallidChildXMLElement);
+Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
+	typedef Node* (*Factory)(const TiXmlElement&, const Parser&);
+	/* tag -> factory; scanned case-insensitively, same order as before. */
+	static const struct { const char* pTag; Factory pMake; } kTable[] = {
+		{ Attribute::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Attribute(e, p); } },
+		{ Choice::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Choice(e, p); } },
+		{ Element::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Element(e, p); } },
+		{ List::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new List(e, p); } },
+		{ Restriction::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Restriction(e, p); } },
+		{ Sequence::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Sequence(e, p); } },
+		{ Union::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Union(e, p); } },
+		{ Schema::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Schema(e, p, std::string("")); } },
+		{ SimpleType::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new SimpleType(e, p); } },
+		{ ComplexType::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new ComplexType(e, p); } },
+		{ Group::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Group(e, p); } },
+		{ Any::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Any(e, p); } },
+		{ ComplexContent::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new ComplexContent(e, p); } },
+		{ Extension::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Extension(e, p); } },
+		{ SimpleContent::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new SimpleContent(e, p); } },
+		{ MinExclusive::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MinExclusive(e, p); } },
+		{ MaxExclusive::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MaxExclusive(e, p); } },
+		{ MinInclusive::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MinInclusive(e, p); } },
+		{ MaxInclusive::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MaxInclusive(e, p); } },
+		{ MinLength::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MinLength(e, p); } },
+		{ MaxLength::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new MaxLength(e, p); } },
+		{ Length::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Length(e, p); } },
+		{ Enumeration::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Enumeration(e, p); } },
+		{ FractionDigits::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new FractionDigits(e, p); } },
+		{ Pattern::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Pattern(e, p); } },
+		{ TotalDigits::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new TotalDigits(e, p); } },
+		{ WhiteSpace::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new WhiteSpace(e, p); } },
+		{ AttributeGroup::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new AttributeGroup(e, p); } },
+		{ Include::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Include(e, p); } },
+		{ Annotation::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Annotation(e, p); } },
+		{ Documentation::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Documentation(e, p); } },
+		{ All::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new All(e, p); } },
+		{ AppInfo::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new AppInfo(e, p); } },
+	};
+	const std::string elementName = StripNamespace_(pElm->ValueStr());
+	for (const auto& rEntry : kTable) {
+		if (boost::iequals(std::string(rEntry.pTag), elementName))
+			return rEntry.pMake(*pElm, rParser);
+	}
+	throw XMLException(*pElm, XMLException::InvallidChildXMLElement);
 	return NULL;
 }
 
 Node*
-Node::_FindXSDElm(const char* pName, const char* pTypeName) const noexcept(false) {
+Node::FindXSDElm_(const char* pName, const char* pTypeName) const noexcept(false) {
 	std::string elementName = QualifyElementName(pTypeName);
 	/* search root document */
 	Node* pRetNode = NULL;
 	std::unique_ptr<Schema> pSchemaRoot(GetSchema());
-	const TiXmlElement* pElm = pSchemaRoot->_FindChildXMLElement(elementName.c_str(), "name", pName);
+	const TiXmlElement* pElm = pSchemaRoot->FindChildXMLElement_(elementName.c_str(), "name", pName);
 	/* search all included documents */
 	if (!pElm) {
 		const TiXmlElement* pIncludElm = pSchemaRoot->GetXMLElm().FirstChildElement(XSD::Elements::Include::XSDTag());
 		for ( ; pIncludElm; pIncludElm = pIncludElm->NextSiblingElement(XSD::Elements::Include::XSDTag()) ) {
-			std::unique_ptr<Include> pNode(static_cast<Include*>(_ConstructNode(pIncludElm, m_rParser)));
+			std::unique_ptr<Include> pNode(static_cast<Include*>(ConstructNode_(pIncludElm, m_rParser)));
 			const Schema* pSchema = pNode->QuerySchema();
-			if (NULL != (pElm = pSchema->_FindChildXMLElement(elementName.c_str(), "name", pName))) {
-				pRetNode = _ConstructNode(pElm, pSchema->m_rParser);
+			if (NULL != (pElm = pSchema->FindChildXMLElement_(elementName.c_str(), "name", pName))) {
+				pRetNode = ConstructNode_(pElm, pSchema->m_rParser);
 				break;
 			}
 		}
 	} else
-		pRetNode = _ConstructNode(pElm, m_rParser);
+		pRetNode = ConstructNode_(pElm, m_rParser);
 	return pRetNode;
 }
 
 Node*
-Node::_FindXSDNode(const char* pName, const char* pTypeName) const noexcept(false) {
-	Node* pNode = _FindXSDElm(pName, pTypeName);
+Node::FindXSDNode_(const char* pName, const char* pTypeName) const noexcept(false) {
+	Node* pNode = FindXSDElm_(pName, pTypeName);
 	if (!pNode)
 		throw XMLException(m_rXmlElm, XMLException::MissingElement);
 	return pNode;
 }
 
 Node*
-Node::_FindChildXSDNode(const char* pXMLTag) const noexcept(false) {
+Node::FindChildXSDNode_(const char* pXMLTag) const noexcept(false) {
 	std::string elementName = QualifyElementName(pXMLTag);
 	/* search all nodes in root document */
 	const TiXmlElement* pElm = m_rXmlElm.FirstChildElement(elementName.c_str());
 	if (NULL == pElm)
 		throw XMLException(m_rXmlElm, XMLException::MissingChildXMLElement);
-	return _ConstructNode(pElm, m_rParser);
+	return ConstructNode_(pElm, m_rParser);
 }
 
 Node*
-Node::_FindXSDRef(const char* pRefAttribStr, const char* pTypeName) const noexcept(false) {
+Node::FindXSDRef_(const char* pRefAttribStr, const char* pTypeName) const noexcept(false) {
 	if (HasAttribute(pRefAttribStr)) {
-		std::unique_ptr<Node> pRefElm(_FindXSDNode(GetAttribute<const char*>(pRefAttribStr), pTypeName));
-		return pRefElm->_FindXSDRef(pRefAttribStr, pTypeName);
+		std::unique_ptr<Node> pRefElm(FindXSDNode_(GetAttribute<const char*>(pRefAttribStr), pTypeName));
+		return pRefElm->FindXSDRef_(pRefAttribStr, pTypeName);
 	} else
-		return _ConstructNode(&m_rXmlElm, m_rParser);
+		return ConstructNode_(&m_rXmlElm, m_rParser);
 }
 
 std::string
-Node::_Attribute(const char* pAttrib) const noexcept(false) {
+Node::Attribute_(const char* pAttrib) const noexcept(false) {
 	if (HasAttribute(pAttrib)) {
 		return std::string(m_rXmlElm.Attribute(pAttrib));
 	} else
@@ -269,29 +310,26 @@ Node::_Attribute(const char* pAttrib) const noexcept(false) {
 }
 
 Types::BaseType*
-Node::_Type(const char* pType) const noexcept(false) {
+Node::Type_(const char* pType) const noexcept(false) {
 	/* search for type name */
-	std::string typeName = _StripNamespace(std::string(pType));
+	std::string typeName = StripNamespace_(std::string(pType));
 	Types::BaseType* pRetType = m_rParser.QueryTypesDb().FindType(typeName.c_str());
 	if (typeid(*pRetType) == typeid(Types::Unknown)) {
-		Node* pSimpleType	= _FindXSDElm(typeName.c_str(), SimpleType::XSDTag());
-		Node* pComplexType	= _FindXSDElm(typeName.c_str(), ComplexType::XSDTag());
-		if (NULL != pSimpleType) {
-			delete pRetType;
-			pRetType = new Types::SimpleType(static_cast<SimpleType*>(pSimpleType));
-		} else if (NULL != pComplexType) {
-			delete pRetType;
-			pRetType=  new Types::ComplexType(static_cast<ComplexType*>(pComplexType));
-		} else {
-			delete pRetType;
-			throw XMLException(m_rXmlElm, XMLException::MissingElement);
-		}
+		delete pRetType;
+		Node* pSimpleType = FindXSDElm_(typeName.c_str(), SimpleType::XSDTag());
+		if (NULL != pSimpleType)
+			return new Types::SimpleType(static_cast<SimpleType*>(pSimpleType));
+		Node* pComplexType = FindXSDElm_(typeName.c_str(), ComplexType::XSDTag());
+		if (NULL != pComplexType)
+			return new Types::ComplexType(
+				static_cast<ComplexType*>(pComplexType));
+		throw XMLException(m_rXmlElm, XMLException::MissingElement);
 	}
 	return pRetType;
 }
 
 const std::string 
-Node::_StripNamespace(const std::string& rQName) const noexcept(false) {
+Node::StripNamespace_(const std::string& rQName) const noexcept(false) {
 	std::unique_ptr<Schema> pSchema(GetSchema());
 	std::string xmlNamespace = pSchema->Namespace();
 	/* verify that the namespace is in the qualified name */
@@ -305,45 +343,51 @@ Node::_StripNamespace(const std::string& rQName) const noexcept(false) {
 	return rQName;
 }
 
-Node* 
+Node*
 Node::Parent() const noexcept(false) {
 	const TiXmlElement* pElm = m_rXmlElm.Parent()->ToElement();
-	return pElm ? _ConstructNode(pElm, m_rParser) : NULL;
+	return pElm ? ConstructNode_(pElm, m_rParser) : NULL;
+}
+
+/* virtual */ Types::BaseType*
+Node::GetParentType() const noexcept(false) {
+	std::unique_ptr<Node> pParent(Node::Parent());
+	return pParent->GetParentType();
 }
 
 Node*
 Node::FirstChild() const noexcept(false) {
 	const TiXmlElement* pElm = m_rXmlElm.FirstChildElement();
-	return pElm ? _ConstructNode(pElm, m_rParser) : NULL;
+	return pElm ? ConstructNode_(pElm, m_rParser) : NULL;
 }
 Node*
 Node::NextSibling() const noexcept(false) {
 	const TiXmlElement* pElm = m_rXmlElm.NextSiblingElement();
-	return pElm ? _ConstructNode(pElm, m_rParser) : NULL;
+	return pElm ? ConstructNode_(pElm, m_rParser) : NULL;
 }
 
 /* Recurse the sibling chain from pNode until rFn returns true. */
 static bool
-_findSibling(std::unique_ptr<Node> pNode,
+findSibling_(std::unique_ptr<Node> pNode,
 		const std::function<bool(const Node&)>& rFn) noexcept(false) {
 	if (NULL == pNode.get())
 		return false;
 	if (rFn(*pNode))
 		return true;
-	return _findSibling(std::unique_ptr<Node>(pNode->NextSibling()), rFn);
+	return findSibling_(std::unique_ptr<Node>(pNode->NextSibling()), rFn);
 }
 
 bool
-Node::_findChild(
+Node::findChild_(
 		const std::function<bool(const Node&)>& rFn) const noexcept(false) {
-	return _findSibling(std::unique_ptr<Node>(FirstChild()), rFn);
+	return findSibling_(std::unique_ptr<Node>(FirstChild()), rFn);
 }
 
 void
-Node::_eachChild(
+Node::eachChild_(
 		const std::function<void(const Node&)>& rFn) const noexcept(false) {
 	/* visit-all expressed via the short-circuiting search */
-	_findChild([&rFn](const Node& rNode) -> bool { rFn(rNode); return false; });
+	findChild_([&rFn](const Node& rNode) -> bool { rFn(rNode); return false; });
 }
 
 const TiXmlElement*
@@ -386,6 +430,47 @@ Node::HasContent() const throw() {
 			return true;
 	}
 	return false;
+}
+
+int
+Node::maxOccurs_(int dflt) const noexcept(false) {
+	if (HasAttribute("maxOccurs")) {
+		if (strcmp(GetAttribute<const char*>("maxOccurs"), "unbounded"))
+			return GetAttribute<int>("maxOccurs");
+		else
+			return -1;
+	}
+	return dflt;
+}
+
+int
+Node::minOccurs_(int dflt) const noexcept(false) {
+	if (HasAttribute("minOccurs"))
+		return GetAttribute<int>("minOccurs");
+	return dflt;
+}
+
+Types::BaseType*
+Node::delegateToSoleChild_() const noexcept(false) {
+	std::unique_ptr<Restriction> pRestriction(
+		SearchXSDChildElm<Restriction>());
+	std::unique_ptr<Extension> pExtension(SearchXSDChildElm<Extension>());
+	if ((NULL != pRestriction.get()) && (NULL == pExtension.get())) {
+		return pRestriction->GetParentType();
+	} else if ((NULL == pRestriction.get()) && (NULL != pExtension.get())) {
+		return pExtension->GetParentType();
+	} else /* content can't have multiple child modifiers */
+		throw XMLException(GetXMLElm(), XMLException::InvallidChildXMLElement);
+}
+
+Types::BaseType*
+Node::baseType_() const noexcept(false) {
+	return GetAttribute<Types::BaseType*>("base");
+}
+
+std::string
+Node::name_() const noexcept(false) {
+	return std::string(GetAttribute<const char*>("name"));
 }
 
 bool

--- a/src/XSDParser/Elements/Node.hpp
+++ b/src/XSDParser/Elements/Node.hpp
@@ -56,19 +56,19 @@ namespace XSD {
 
 			Node();
 			const TiXmlElement* ContentElement(const char* pElemName) const noexcept(false);
-			const TiXmlElement* _FindChildXMLElement(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false);
-			Node* _FindXSDElm(const char* pName, const char* pTypeName) const noexcept(false);
-			Node* _ConstructNode(const TiXmlElement* pElm, const Parser& rParser) const;
-			Node* _FindXSDNode(const char* pName, const char* pTypeName) const noexcept(false);
-			Node* _FindChildXSDNode(const char* pXMLTag) const noexcept(false);
-			Node* _FindXSDRef(const char* pRefAttribStr, const char* pTypeName) const noexcept(false);
-			std::string _Attribute(const char* pAttrib) const noexcept(false);
-			Types::BaseType* _Type(const char* pType) const noexcept(false);
-			const std::string _StripNamespace(const std::string& rQName) const noexcept(false);
+			const TiXmlElement* FindChildXMLElement_(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false);
+			Node* FindXSDElm_(const char* pName, const char* pTypeName) const noexcept(false);
+			Node* ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const;
+			Node* FindXSDNode_(const char* pName, const char* pTypeName) const noexcept(false);
+			Node* FindChildXSDNode_(const char* pXMLTag) const noexcept(false);
+			Node* FindXSDRef_(const char* pRefAttribStr, const char* pTypeName) const noexcept(false);
+			std::string Attribute_(const char* pAttrib) const noexcept(false);
+			Types::BaseType* Type_(const char* pType) const noexcept(false);
+			const std::string StripNamespace_(const std::string& rQName) const noexcept(false);
 		protected:
 			Node(const TiXmlElement& elm, const Parser& rParser);
 			Node(const Node& rCpy);
-			Types::BaseType* LookupType(const char* pType) const noexcept(false) { return _Type(pType); }
+			Types::BaseType* LookupType(const char* pType) const noexcept(false) { return Type_(pType); }
 			/* QueryRootElement(): returns the root element of the document containg the node*/
 			const TiXmlElement& QueryRootElement() const;
 			Schema * GetSchema() const noexcept(false);
@@ -77,25 +77,36 @@ namespace XSD {
 			bool HasContent(const char* pElemName) const noexcept;
 			bool HasContent() const noexcept;
 			bool IsRootNode() const noexcept;
+			/* Shared maxOccurs/minOccurs reads: absent -> dflt, "unbounded"
+			 * -> -1. Used by the byte-identical Choice/Group/Any overrides. */
+			int maxOccurs_(int dflt) const noexcept(false);
+			int minOccurs_(int dflt) const noexcept(false);
+			/* GetParentType for nodes whose type comes from a single child
+			 * restriction xor extension (simpleContent/complexContent). */
+			Types::BaseType* delegateToSoleChild_() const noexcept(false);
+			/* The "base" attribute as a type; shared by restriction/extension. */
+			Types::BaseType* baseType_() const noexcept(false);
+			/* The "name" attribute as a string; shared by named nodes. */
+			std::string name_() const noexcept(false);
 			std::string QualifyElementName(const char* pElemName) const noexcept;
 			template<typename T> T GetAttribute(const char* pAttrib) const noexcept(false) {
 				T retVal;
-				std::stringstream sstrm(_Attribute(pAttrib));
+				std::stringstream sstrm(Attribute_(pAttrib));
 				sstrm >> retVal;
 				return retVal;
 			}
 			template<typename T> T* FindXSDElm(const char* pName) const noexcept(false) {
-				return static_cast<T*>(_FindXSDNode(pName, T::XSDTag()));
+				return static_cast<T*>(FindXSDNode_(pName, T::XSDTag()));
 			}
 			template<typename T> T* FindXSDRef(const char* pRefAttribStr) const noexcept(false) {
-				return static_cast<T*>(_FindXSDRef(pRefAttribStr, T::XSDTag()));
+				return static_cast<T*>(FindXSDRef_(pRefAttribStr, T::XSDTag()));
 			}
 			template<typename T> T* FindXSDChildElm() const noexcept(false) {
-				return static_cast<T*>(_FindChildXSDNode(T::XSDTag()));
+				return static_cast<T*>(FindChildXSDNode_(T::XSDTag()));
 			}
 			template<typename T> T* SearchXSDChildElm() const noexcept {
 				try {
-					return static_cast<T*>(_FindChildXSDNode(T::XSDTag()));
+					return static_cast<T*>(FindChildXSDNode_(T::XSDTag()));
 				} catch (XMLException& e) {
 					return NULL;
 				}
@@ -104,26 +115,27 @@ namespace XSD {
 			virtual ~Node();
 			virtual void ParseChildren(BaseProcessor& rProcessor) const noexcept(false) = 0;
 			virtual void ParseElement(BaseProcessor& rProcessor) const noexcept(false) = 0;
-			/* for "element" : return their type 
+			/* for "element" : return their type
 			 * for "simpleType/complexType" : return the base type of their child elements
 			 * for "simpleContent/complexContent" : return type of their child restriction/extension elements
 			 * for "restriction/extension": return base type
 			 * for "list" : return type
 			 * for "union" : return xs:string HACK
-			 * for all other elements: return the type they are enclosed in */
-			virtual Types::BaseType * GetParentType() const noexcept(false) = 0;
+			 * for all other elements: return the type they are enclosed in
+			 * (the default — delegate to the enclosing parent) */
+			virtual Types::BaseType * GetParentType() const noexcept(false);
 			Node* Parent() const noexcept(false);
 			Node* FirstChild() const noexcept(false);
 			Node* NextSibling() const noexcept(false);
 			/* Recurse over the child sibling chain, invoking rFn on each
 			 * child. Functional replacement for the do/while NextSibling
 			 * loops in the ParseChildren overrides. */
-			void _eachChild(
+			void eachChild_(
 				const std::function<void(const Node&)>& rFn) const noexcept(false);
 			/* Recurse the child sibling chain until rFn returns true (a
 			 * short-circuiting search); returns true if some child matched.
 			 * Functional replacement for the do/while search loops. */
-			bool _findChild(
+			bool findChild_(
 				const std::function<bool(const Node&)>& rFn) const noexcept(false);
 			bool operator == (const Node& elm) const;
 			bool operator == (const Node& elm);

--- a/src/XSDParser/Elements/Pattern.cpp
+++ b/src/XSDParser/Elements/Pattern.cpp
@@ -35,42 +35,19 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 Pattern::Pattern(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 Pattern::Pattern(const Pattern& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-Pattern::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 Pattern::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessPattern(this);
 }
 
-Types::BaseType * 
-Pattern::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
 std::string
 Pattern::Value() const noexcept(false) {
 	return std::string(Node::GetAttribute<const char*>("value"));
-}
-
-bool
-Pattern::HasValue() const {
-	return Node::HasAttribute("value");
 }

--- a/src/XSDParser/Elements/Pattern.hpp
+++ b/src/XSDParser/Elements/Pattern.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class Pattern : public Node {
+		class Pattern : public FacetNode<Pattern, std::string> {
 			XSD_ELEMENT_TAG("pattern")
 		private:
 			Pattern();
 		public:
 			Pattern(const TiXmlElement& elm, const Parser& rParser);
 			Pattern(const Pattern& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
-			Types::BaseType * GetParentType() const noexcept(false);
 			std::string Value() const noexcept(false);
-			bool HasValue() const;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Restriction.cpp
+++ b/src/XSDParser/Elements/Restriction.cpp
@@ -65,7 +65,7 @@ void
 Restriction::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	if (isParentComplexContent()) {
 		/* process children */
-		_eachChild([&rProcessor](const Node& rNode) {
+		eachChild_([&rProcessor](const Node& rNode) {
 			if (XSD_ISELEMENT(&rNode, Group) ||
 				XSD_ISELEMENT(&rNode, Choice) ||
 				XSD_ISELEMENT(&rNode, Sequence) ||
@@ -79,7 +79,7 @@ Restriction::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 		});
 	} else if (isParentSimpleContent()){
 		/* process children */
-		_eachChild([&rProcessor](const Node& rNode) {
+		eachChild_([&rProcessor](const Node& rNode) {
 			if (XSD_ISELEMENT(&rNode, XSD::Elements::Attribute) ||
 				XSD_ISELEMENT(&rNode, XSD::Elements::MinExclusive) ||
 				XSD_ISELEMENT(&rNode, XSD::Elements::MaxExclusive) ||
@@ -101,7 +101,7 @@ Restriction::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	} else {
 		/* process children */
 		std::unique_ptr<Types::BaseType> pBase(Base());
-		_eachChild([&rProcessor, &pBase](const Node& rNode) {
+		eachChild_([&rProcessor, &pBase](const Node& rNode) {
 			if (XSD_ISELEMENT(&rNode, XSD::Elements::MinExclusive) ||
 				XSD_ISELEMENT(&rNode, XSD::Elements::MaxExclusive) ||
 				XSD_ISELEMENT(&rNode, XSD::Elements::MinInclusive) ||
@@ -160,71 +160,16 @@ Restriction::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 		Processors::RestrictionVerify verifyRestriciton;
 		if (!verifyRestriciton.Verify(this, pCmplxType->m_pValue))
 			throw XMLException(GetXMLElm(), XMLException::RestrictionTypeMismatch);
-		/*
-		if (!_isElmRelated(this, &pCmplxType->m_pValue->GetXMLElm()))
-			throw XMLException(GetXMLElm(), XMLException::RestrictionTypeMismatch);
-		*/
 	}
 	/* process element */
 	rProcessor.ProcessRestriction(this);
 }
 
-Types::BaseType * 
+Types::BaseType *
 Restriction::GetParentType() const noexcept(false) {
 	return this->Base();
 }
 
-/*static * bool
-Restriction::_isElmRelated(const Node* pRstrctn, const TiXmlElement* pBase) const noexcept(false) {
-	std::unique_ptr<Node> pRstrctnChld(pRstrctn->FirstChild());
-	* iterate through children comparing against parent type *
-	if (NULL != pRstrctnChld.get()) {
-	  do {
-			if (!(XSD_ISELEMENT(pRstrctnChld.get(), Annotation))) {
-				* find node in parent XSD type *
-				const TiXmlElement* pFndElm = _findElm(pBase, &(pRstrctnChld.get()->GetXMLElm()));
-				if (pFndElm) {
-					if (_isElmRelated(pRstrctnChld.get(), pFndElm) == false )
-						return false;
-				} else
-					return false;
-			}
-		} while (NULL != (pRstrctnChld = std::unique_ptr<Node>(pRstrctnChld->NextSibling())).get());
-	}
-	return true;
-}
-
-* static * const TiXmlElement*
-Restriction::_findElm(const TiXmlElement* pTreeBase, const TiXmlElement* pNode) noexcept(false) {
-	const TiXmlElement* pBaseChld = pTreeBase->FirstChildElement(pNode->Value());
-	bool cmpHasName = (pNode->Attribute("name") != NULL);
-	bool cmpHasType = (pNode->Attribute("type") != NULL);
-	for ( ; pBaseChld ; pBaseChld = pBaseChld->NextSiblingElement(pNode->Value())) {
-		if (cmpHasName) {
-			if (pBaseChld->Attribute("name") != NULL) {
-				if (0 == strcmp(pNode->Attribute("name"), pBaseChld->Attribute("name")))
-					return pBaseChld;
-				else
-					continue;
-			} else {
-				continue;
-			}
-		}
-		if (cmpHasType) {
-			if (pBaseChld->Attribute("type") != NULL) {
-				if (0 == strcmp(pNode->Attribute("type"), pBaseChld->Attribute("type")))
-					return pBaseChld;
-				else
-					continue;
-			} else {
-				continue;
-			}
-		}
-		return pBaseChld; * !cmpHasName && !cmpHasType *
-	}
-	return NULL;
-}
-*/
 bool
 Restriction::isParentComplexContent() const noexcept(false) {
 	std::unique_ptr<Node> pParent(Node::Parent());
@@ -239,5 +184,5 @@ Restriction::isParentSimpleContent() const noexcept(false) {
 
 Types::BaseType*
 Restriction::Base() const noexcept(false) {
-	return Node::GetAttribute<Types::BaseType*>("base");
+	return Node::baseType_();
 }

--- a/src/XSDParser/Elements/Restriction.hpp
+++ b/src/XSDParser/Elements/Restriction.hpp
@@ -35,8 +35,6 @@ namespace XSD {
 			XSD_ELEMENT_TAG("restriction")
 		private:
 			Restriction();
-			// bool _isElmRelated(const Node* pRstrctn, const TiXmlElement* pBase) const noexcept(false);
-			//static const TiXmlElement* _findElm(const TiXmlElement* pTreeBase, const TiXmlElement* pNode) noexcept(false);
 		public:
 			Restriction(const TiXmlElement& elm, const Parser& rParser);
 			Restriction(const Restriction& rCpy);

--- a/src/XSDParser/Elements/Schema.cpp
+++ b/src/XSDParser/Elements/Schema.cpp
@@ -1,5 +1,5 @@
 /*
- * Document.cpp
+ * Schema.cpp
  *
  *  Created on: Jun 26, 2011
  *      Author: QVXLabs LLC
@@ -47,7 +47,7 @@ Schema::~Schema()
 void
 Schema::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Element) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Include)) {
@@ -63,7 +63,7 @@ Schema::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 
 const std::string
 Schema::Name() const noexcept(false) {
-	return _extractName(m_documentURI);
+	return extractName_(m_documentURI);
 }
 
 const std::string&
@@ -101,6 +101,6 @@ Schema::isRootSchema() const {
 }
 
 /* static */ std::string
-Schema::_extractName(const std::string& uri) {
+Schema::extractName_(const std::string& uri) {
 	return Util::StripFileExtension(Util::ExtractResourceName(uri));
 }

--- a/src/XSDParser/Elements/Schema.hpp
+++ b/src/XSDParser/Elements/Schema.hpp
@@ -38,7 +38,7 @@ namespace XSD {
 		private:
 			std::string		m_documentURI;
 			Schema();
-			static std::string _extractName(const std::string& uri);			
+			static std::string extractName_(const std::string& uri);			
 		public:
 			Schema(const TiXmlElement& elm, const Parser& rParser, const std::string& uri);
 			Schema( const Schema& elm);

--- a/src/XSDParser/Elements/Sequence.cpp
+++ b/src/XSDParser/Elements/Sequence.cpp
@@ -41,7 +41,7 @@ Sequence::Sequence(const Sequence& rCpy)
 void
 Sequence::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Element) ||
 			XSD_ISELEMENT(&rNode, Choice) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
@@ -56,12 +56,6 @@ Sequence::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 void
 Sequence::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessSequence(this);
-}
-
-Types::BaseType * 
-Sequence::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
 }
 
 bool

--- a/src/XSDParser/Elements/Sequence.hpp
+++ b/src/XSDParser/Elements/Sequence.hpp
@@ -42,7 +42,6 @@ namespace XSD {
 			Sequence(const Sequence& rCpy);
 			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
 			bool HasElements() const noexcept(false);;
 		};
 	}	/* namespace Elements */

--- a/src/XSDParser/Elements/SimpleContent.cpp
+++ b/src/XSDParser/Elements/SimpleContent.cpp
@@ -46,7 +46,7 @@ SimpleContent::SimpleContent(const SimpleContent& rType)
 void
 SimpleContent::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Restriction) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Extension)) {
@@ -63,12 +63,5 @@ SimpleContent::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 
 Types::BaseType *
 SimpleContent::GetParentType() const noexcept(false) {
-	std::unique_ptr<Restriction> pRestriction(Node::SearchXSDChildElm<Restriction>());
-	std::unique_ptr<Extension> pExtension(Node::SearchXSDChildElm<Extension>());
-	if ((NULL != pRestriction.get()) && (NULL == pExtension.get())) {
-		return pRestriction->GetParentType();
-	} else if ((NULL == pRestriction.get()) && (NULL != pExtension.get())) {
-		return pExtension->GetParentType();
-	} else /* simple content can't have multiple child modifiers */
-		throw XMLException(Node::GetXMLElm(), XMLException::InvallidChildXMLElement);
+	return Node::delegateToSoleChild_();
 }

--- a/src/XSDParser/Elements/SimpleType.cpp
+++ b/src/XSDParser/Elements/SimpleType.cpp
@@ -45,7 +45,7 @@ SimpleType::SimpleType(const SimpleType& rType)
 void
 SimpleType::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Restriction) ||
 			XSD_ISELEMENT(&rNode, List) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
@@ -87,7 +87,7 @@ SimpleType::GetRestriction() const noexcept {
 
 std::string
 SimpleType::Name() const noexcept(false) {
-	return std::string(this->GetAttribute<const char*>("name"));
+	return Node::name_();
 }
 
 bool

--- a/src/XSDParser/Elements/TotalDigits.cpp
+++ b/src/XSDParser/Elements/TotalDigits.cpp
@@ -36,42 +36,15 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 TotalDigits::TotalDigits(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 TotalDigits::TotalDigits(const TotalDigits& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-TotalDigits::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 TotalDigits::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessTotalDigits(this);
 }
 
-Types::BaseType * 
-TotalDigits::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
-}
-
-uint64_t
-TotalDigits::Value() const noexcept(false) {
-	return Node::GetAttribute<uint64_t>("value");
-}
-
-bool
-TotalDigits::HasValue() const {
-	return Node::HasAttribute("value");
-}

--- a/src/XSDParser/Elements/TotalDigits.hpp
+++ b/src/XSDParser/Elements/TotalDigits.hpp
@@ -29,20 +29,18 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class TotalDigits : public Node {
+		class TotalDigits
+				: public FacetNode<TotalDigits, uint64_t> {
 			XSD_ELEMENT_TAG("totalDigits")
 		private:
 			TotalDigits();
 		public:
 			TotalDigits(const TiXmlElement& elm, const Parser& rParser);
 			TotalDigits(const TotalDigits& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			Types::BaseType * GetParentType() const noexcept(false);;
-			uint64_t Value() const noexcept(false);;
-			bool HasValue() const;
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Elements/Union.cpp
+++ b/src/XSDParser/Elements/Union.cpp
@@ -48,7 +48,7 @@ Union::Union(const Union& rCpy)
 void
 Union::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* process children */
-	_eachChild([&rProcessor](const Node& rNode) {
+	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, SimpleType) ||
 			XSD_ISELEMENT(&rNode, Annotation)) {
 			rNode.ParseElement(rProcessor);

--- a/src/XSDParser/Elements/WhiteSpace.cpp
+++ b/src/XSDParser/Elements/WhiteSpace.cpp
@@ -35,34 +35,16 @@ using namespace XSD;
 using namespace XSD::Elements;
 
 WhiteSpace::WhiteSpace(const TiXmlElement& elm, const Parser& rParser)
-	: Node(elm, rParser)
+	: FacetNode(elm, rParser)
 { }
 
 WhiteSpace::WhiteSpace(const WhiteSpace& cpy)
-	: Node(cpy)
+	: FacetNode(cpy)
 { }
-
-void
-WhiteSpace::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
-}
 
 void
 WhiteSpace::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessWhiteSpace(this);
-}
-
-Types::BaseType * 
-WhiteSpace::GetParentType() const noexcept(false) {
-	std::unique_ptr<Node> pParent(Node::Parent());
-	return pParent->GetParentType();
 }
 
 WhiteSpace::eOperation
@@ -78,9 +60,4 @@ WhiteSpace::Value() const noexcept(false) {
 		throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
 		return PRESERVE;
 	}
-}
-
-bool
-WhiteSpace::HasValue() const {
-	return Node::HasAttribute("value");
 }

--- a/src/XSDParser/Elements/WhiteSpace.hpp
+++ b/src/XSDParser/Elements/WhiteSpace.hpp
@@ -29,9 +29,11 @@
 #endif /* TIXML_USE_STL */
 #include <tinyxml.h>
 #include "./src/XSDParser/Elements/Node.hpp"
+#include "./src/XSDParser/Elements/FacetNode.hpp"
 namespace XSD {
 	namespace Elements {
-		class WhiteSpace : public Node {
+		/* enum Value() is a leaf-specific override; base ValueT is unused. */
+		class WhiteSpace : public FacetNode<WhiteSpace, int> {
 			XSD_ELEMENT_TAG("whiteSpace")
 		private:
 			WhiteSpace();
@@ -43,11 +45,8 @@ namespace XSD {
 			};
 			WhiteSpace(const TiXmlElement& elm, const Parser& rParser);
 			WhiteSpace(const WhiteSpace& cpy);
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
 			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
-			Types::BaseType * GetParentType() const noexcept(false);
 			eOperation Value() const noexcept(false);
-			bool HasValue() const;
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */

--- a/src/XSDParser/Exception.cpp
+++ b/src/XSDParser/Exception.cpp
@@ -25,7 +25,7 @@
 
 using namespace XSD;
 
-static const char* _ERRORTBL[] ={
+static const char* ERRORTBL_[] ={
 		ENUM_STR(TIXML_NO_ERROR),
 		ENUM_STR(TIXML_ERROR),
 		ENUM_STR(TIXML_ERROR_OPENING_FILE),
@@ -72,15 +72,15 @@ XMLException::ErrorInfo::ErrorInfo(const ErrorInfo& err)
 
 XMLException::XMLException(const TiXmlDocument& doc) throw ()
 	: m_errorInfo(doc.ErrorId(), doc.ErrorRow(), doc.ErrorCol())
-{ _createErrorString(); }
+{ createErrorString_(); }
 
 XMLException::XMLException(const XMLException& excpt) throw ()
 	: m_errorInfo(excpt.m_errorInfo)
-{ _createErrorString(); }
+{ createErrorString_(); }
 
 XMLException::XMLException(const TiXmlBase& elem, int id) throw()
 	: m_errorInfo(id, elem.Row(), elem.Column())
-{ _createErrorString(); }
+{ createErrorString_(); }
 
 /* virtual */
 XMLException::~XMLException() throw ()
@@ -97,9 +97,9 @@ XMLException::what() const throw() {
 }
 
 void
-XMLException::_createErrorString() throw (){
+XMLException::createErrorString_() throw (){
 	std::stringstream strStrm(m_errorMsg);
-	strStrm << "XSD Parse Error: " << _ERRORTBL[m_errorInfo.m_errorId]
+	strStrm << "XSD Parse Error: " << ERRORTBL_[m_errorInfo.m_errorId]
 	        << "(" << m_errorInfo.m_errorId << ") row:" << m_errorInfo.m_docRow
 	        << " col: " << m_errorInfo.m_docCol << std::endl;
 	m_errorMsg = strStrm.str();

--- a/src/XSDParser/Exception.hpp
+++ b/src/XSDParser/Exception.hpp
@@ -67,7 +67,7 @@ namespace XSD {
 		const ErrorInfo	m_errorInfo;
 		XMLException();
 		XMLException& operator= (const XMLException&) throw();
-		void _createErrorString() throw();
+		void createErrorString_() throw();
 	};
 }	/* namespace XSD */
 #endif /* XSDEXCEPTION_HPP_ */

--- a/src/XSDParser/Parser.cpp
+++ b/src/XSDParser/Parser.cpp
@@ -45,11 +45,30 @@ Parser::Parse(const char* pUri) const noexcept(false) {
 	return Parse(uri);
 }
 
+Parser::DocumentRecord*
+Parser::findByUri_(const std::string& rUri) const {
+	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
+		if ((*i)->m_uri == rUri)
+			return *i;
+	}
+	return NULL;
+}
+
+Parser::DocumentRecord*
+Parser::findByDoc_(const TiXmlDocument& document) const {
+	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
+		if ((*i)->m_pDocument == &document)
+			return *i;
+	}
+	return NULL;
+}
+
 Elements::Schema*
 Parser::Parse(const std::string& rUri) const noexcept(false) {
 	/* search if the document has already been parsed */
-	if (HasDocument(rUri)) {
-		return new Elements::Schema(*(GetDocument(rUri)->RootElement()), *this, rUri);
+	if (DocumentRecord* pRec = findByUri_(rUri)) {
+		return new Elements::Schema(*(pRec->m_pDocument->RootElement()),
+			*this, rUri);
 	} else {
 		m_docLst.push_back(new DocumentRecord(new TiXmlDocument(), rUri));
 		TiXmlDocument * pDoc = m_docLst.back()->m_pDocument;
@@ -77,40 +96,26 @@ Parser::QueryTypesDb() const throw() {
 	return m_typesDb;
 }
 
-bool 
+bool
 Parser::HasDocument(const TiXmlDocument& document) const {
-	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
-		if ((*i)->m_pDocument == &document) 
-			return true;
-	}
-	return false;
+	return NULL != findByDoc_(document);
 }
 
-bool 
+bool
 Parser::HasDocument(const std::string& rUri) const {
-	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
-		if ((*i)->m_uri == rUri) 
-			return true;
-	}
-	return false;
+	return NULL != findByUri_(rUri);
 }
 
-std::string 
+std::string
 Parser::GetUri(const TiXmlDocument& document) const {
-	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
-		if ((*i)->m_pDocument == &document) 
-			return (*i)->m_uri;
-	}
-	return std::string("unknown");
+	DocumentRecord* pRec = findByDoc_(document);
+	return pRec ? pRec->m_uri : std::string("unknown");
 }
 
 const TiXmlDocument *
 Parser::GetDocument(const std::string& rUri) const {
-	for (XmlDocList::iterator i = m_docLst.begin(); i != m_docLst.end(); ++i) {
-		if ((*i)->m_uri == rUri) 
-			return (*i)->m_pDocument;
-	}
-	return NULL;
+	DocumentRecord* pRec = findByUri_(rUri);
+	return pRec ? pRec->m_pDocument : NULL;
 }
 
 bool 

--- a/src/XSDParser/Parser.hpp
+++ b/src/XSDParser/Parser.hpp
@@ -47,6 +47,8 @@ namespace XSD {
 		typedef std::vector<DocumentRecord *> XmlDocList;
 		Types::TypesDB 		m_typesDb;
 	    mutable XmlDocList	m_docLst;
+		DocumentRecord* findByUri_(const std::string& rUri) const;
+		DocumentRecord* findByDoc_(const TiXmlDocument& document) const;
 	public:
 		Parser();
 		virtual ~Parser();

--- a/src/XSDParser/Types.cpp
+++ b/src/XSDParser/Types.cpp
@@ -32,73 +32,38 @@
 
 using namespace XSD;
 using namespace XSD::Types;
-/*
- * XSDSimpleTypeType - XSD type object for XSD simple types
- */
-/* virtual */ BaseType*
-SimpleType::clone() const {
-	return new SimpleType(this->m_pValue);
-}
 
-/* virtual */ bool
-SimpleType::isTypeRelated(const BaseType* pType) const {
-	/* check if pType is the same type as this */
-	if (XSD_ISTYPE(pType, SimpleType)) {
-		const SimpleType *pCmpSimpleType = static_cast<const SimpleType*>(pType);
-		if (*m_pValue == *pCmpSimpleType->m_pValue)
-				return true;
+/* The two XSD-element-backed wrapper types share identical bodies (only the
+ * wrapper type name differs). isTypeRelated checks identity then walks the
+ * value's parent type. */
+#define WRAPPED_TYPE_DEFN(TYPE) \
+	/* virtual */ BaseType* \
+	TYPE::clone() const { \
+		return new TYPE(this->m_pValue); \
+	} \
+	/* virtual */ bool \
+	TYPE::isTypeRelated(const BaseType* pType) const { \
+		if (typeid(*pType) == typeid(TYPE)) { \
+			const TYPE* pCmp = static_cast<const TYPE*>(pType); \
+			if (*m_pValue == *pCmp->m_pValue) \
+				return true; \
+		} \
+		std::unique_ptr<BaseType> pBaseType(m_pValue->GetParentType()); \
+		if (NULL == pBaseType.get()) \
+			return false; \
+		else \
+			return pBaseType->isTypeRelated(pType); \
+	} \
+	/* virtual */ const char* \
+	TYPE::Name() const { \
+		m_name = (m_pValue->HasName()) ? m_pValue->Name() : "Unnamed"; \
+		return m_name.c_str(); \
+	} \
+	/* virtual */ \
+	TYPE::~TYPE() { \
+		delete m_pValue; \
 	}
-	/* break down this simpleType to its parent type */
-	std::unique_ptr<BaseType> pBaseType(m_pValue->GetParentType());
-	if (NULL == pBaseType.get())
-		return false;
-	else
-		return pBaseType->isTypeRelated(pType);
-}
 
-/* virtual */ const char*
-SimpleType::Name() const {
-  m_name = (m_pValue->HasName()) ? m_pValue->Name() : "Unnamed";
-  return m_name.c_str();
-}
-
-/* virtual */
-SimpleType::~SimpleType() {
-	delete m_pValue;
-}
-
-/*
- * XSDComplexTypeType - XSD type object for XSD complex types
- */
-/* virtual */ BaseType*
-ComplexType::clone() const {
-	return new ComplexType(this->m_pValue);
-}
-
-/* virtual */ bool
-ComplexType::isTypeRelated(const BaseType* pType) const {
-	/* check if pType is the same type as this */
-	if (typeid(*pType) == typeid(ComplexType)) {
-		const ComplexType *pCmpCmplxType = static_cast<const ComplexType*>(pType);
-		if (*m_pValue == *pCmpCmplxType->m_pValue)
-				return true;
-	}
-	/* break down complexType to its parent type */
-	std::unique_ptr<BaseType> pBaseType(m_pValue->GetParentType());
-	if (NULL == pBaseType.get())
-		return false;
-	else
-		return pBaseType->isTypeRelated(pType);
-}
-
-/* virtual */ const char*
-ComplexType::Name() const {
-  m_name = (m_pValue->HasName())
-    ? m_pValue->Name() : "Unnamed";
-  return m_name.c_str();
-}
-
-/* virtual */
-ComplexType::~ComplexType() {
-	delete m_pValue;
-}
+WRAPPED_TYPE_DEFN(SimpleType)
+WRAPPED_TYPE_DEFN(ComplexType)
+#undef WRAPPED_TYPE_DEFN

--- a/src/XSDParser/Types.hpp
+++ b/src/XSDParser/Types.hpp
@@ -115,21 +115,27 @@ namespace XSD {
     XSD_TYPEDEF(NMTokens,AnyAtomicType,std::string, NMTOKENS);
     XSD_TYPEDEF(Unsupported,AnySimpleType,void*, Unsupported);
     XSD_TYPEDEF(Unknown,AnySimpleType,void*, Unknown);
-    struct SimpleType : public BaseType {
-      Elements::SimpleType* m_pValue;
-      mutable std::string   m_name;
-      inline SimpleType(Elements::SimpleType* pElm)
-	: m_pValue(pElm), m_name("Unnamed") {} 
+    /* Shared body for the two XSD-element-backed wrapper types. Derived is
+     * the concrete wrapper (for clone()/typeid); Elm is its element type.
+     * clone/isTypeRelated/Name/dtor live in Types.cpp via the WRAPPED_TYPE
+     * macro so the vtable is keyed on the concrete type. */
+    template<typename Derived, typename Elm>
+    struct WrappedType : public BaseType {
+      Elm* m_pValue;
+      mutable std::string m_name;
+      inline WrappedType(Elm* pElm)
+        : m_pValue(pElm), m_name("Unnamed") {}
+    };
+    struct SimpleType : public WrappedType<SimpleType, Elements::SimpleType> {
+      inline SimpleType(Elements::SimpleType* pElm) : WrappedType(pElm) {}
       virtual BaseType* clone() const;
       virtual bool isTypeRelated(const BaseType* pType) const;
       virtual const char* Name() const;
       virtual ~SimpleType();
     };
-    struct ComplexType : public BaseType {
-      Elements::ComplexType* m_pValue;
-      mutable std::string    m_name;
-      inline ComplexType(Elements::ComplexType* pElm)
-        : m_pValue(pElm), m_name("Unnamed") {}
+    struct ComplexType
+        : public WrappedType<ComplexType, Elements::ComplexType> {
+      inline ComplexType(Elements::ComplexType* pElm) : WrappedType(pElm) {}
       virtual BaseType* clone() const;
       virtual bool isTypeRelated(const BaseType* pType) const;
       virtual const char* Name() const;

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -81,7 +81,7 @@ Resource::GetEngineScript(size_t* pRetSz) noexcept {
 
 /* True if `path` is readable. (POSIX access / Windows _access.) */
 static bool
-_readable(const string& path) noexcept {
+readable_(const string& path) noexcept {
 #if defined(_WIN32)
 	return 0 == _access(path.c_str(), 4 /* R_OK */);
 #else
@@ -91,7 +91,7 @@ _readable(const string& path) noexcept {
 
 /* The current user's home directory, or "" if unknown. */
 static string
-_homeDir() noexcept {
+homeDir_() noexcept {
 #if defined(_WIN32)
 	const char* home = getenv("USERPROFILE");
 	return home ? string(home) : string();
@@ -108,7 +108,7 @@ _homeDir() noexcept {
 __attribute__((noinline))
 #endif
 static string
-_exeDir() noexcept {
+exeDir_() noexcept {
 	char buf[4096];
 #if defined(_WIN32)
 	DWORD n = GetModuleFileNameA(NULL, buf, sizeof(buf));
@@ -136,40 +136,40 @@ _exeDir() noexcept {
 string
 Resource::GetTemplatePath(const std::string& templateName) noexcept(false) {
 	/* test if the template name exists */
-	if (_readable(templateName))
+	if (readable_(templateName))
 		return templateName;
 	/* check environment variable for template file */
 	const char * val = getenv("XSDTOOLS_DATA");
 	if (nullptr != val) {
 		string envFilePath(val);
 		envFilePath += "/" + templateName;
-		if (_readable(envFilePath))
+		if (readable_(envFilePath))
 			return envFilePath;
 	}
 	/* check the home directory for template file */
-	string homeDir(_homeDir());
+	string homeDir(homeDir_());
 	if (!homeDir.empty()) {
 		string homeFilePath(homeDir);
 		homeFilePath += "/" + gscHOMEPATH.substr(1) + templateName;
-		if (_readable(homeFilePath))
+		if (readable_(homeFilePath))
 			return homeFilePath;
 	}
 	/* check relative to the executable (relocatable install / tarball) */
-	string exeDir(_exeDir());
+	string exeDir(exeDir_());
 	if (!exeDir.empty()) {
 		const string relPaths[] = {
 			exeDir + "/../share/xsdtools/templates/" + templateName,
 			exeDir + "/templates/" + templateName,
 		};
 		for (const string& relPath : relPaths) {
-			if (_readable(relPath))
+			if (readable_(relPath))
 				return relPath;
 		}
 	}
 	/* check the global directory for template file */
 	string globalFilePath(gscGLOBALPATH);
 	globalFilePath += "/" + templateName;
-	if (_readable(globalFilePath))
+	if (readable_(globalFilePath))
 		return globalFilePath;
 	/* source-tree convenience: ./templates/<name> */
 	string localPath("templates/" + templateName);


### PR DESCRIPTION
Behavior-preserving cleanup of `src/XSDParser` and the Lua processors, plus a codebase-wide rename of private helpers to the trailing-underscore convention.

## Verification
- Full gtest suite: **322 passed, 0 failed** (baseline 322/0).
- `test/xsdparse/*.out` golden corpus is **byte-identical** — zero golden edits.
- Built with the bundled LNUM-patched Lua (`build/`, FetchContent, find_package disabled).

## Simplifications (H1-H4, M1-M8)
- **Facets**: the 12 leaf facet classes share a CRTP `FacetNode<Derived, ValueT>` base (ctor / ParseChildren / Value / HasValue). Enumeration keeps its ParseChildren quirk; Enumeration/Pattern/WhiteSpace keep value-type overrides.
- **GetParentType** is now non-pure with a default parent-delegating body; 11 trivial overrides removed.
- **_ConstructNode** if/else ladder replaced by a tag->factory table scan.
- Dropped the dead embedded `Parser` member in `Include` and its unused include.
- Added shared `Node` helpers: `_maxOccurs`/`_minOccurs` (Choice/Group/Any), `_delegateToSoleChild` (simple/complexContent), `_baseType` (restriction/extension), `_name` (named nodes).
- `Parser` document lookups collapsed onto `_findByUri`/`_findByDoc`, removing the double scan in `Parse`.
- `_Type` short-circuits the complexType lookup and hoists the `delete`.
- `LuaProcessorBase`'s 34 identical callbacks generated via an X-macro.
- `Types.cpp` SimpleType/ComplexType wrappers share a `WrappedType` base + single definition macro.
- Removed the commented `_isElmRelated`/`_findElm` block; fixed the stale `Schema.cpp` header comment.

The preexisting latent quirks (Enumeration::ParseChildren, the SimpleType union dead-branch, Annotation gating in Restriction) were intentionally left untouched.

## Naming convention change
Private helpers move from leading-underscore (`_FindXSDElm`) to trailing-underscore (`FindXSDElm_`) across `src/` and `test/`, and `CLAUDE.md` is updated to document the new convention. Platform/ABI symbols (`_access`, `_NSGetExecutablePath`, incbin `_binary_*`) are deliberately unchanged.

Net diff: ~540 fewer lines in the parser core (before the rename, which is line-symmetric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784963051&installation_id=141995922&pr_number=36&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F36&signature=52ef571db3ba35c20965176c45cbe391c7a0242dc197a5b40f5bad739f6c0141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->