### PR TITLE
E: namespace awareness + xs:import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ All notable changes to xsd-tools are documented here. The format is based on
 - Smallest-type selection: a facet-bounded integer field narrows to the
   smallest type that holds its range — C `uint8_t`…`int64_t`, Java
   `Byte`/`Short`/`Integer`/`Long`; Python is unaffected (arbitrary precision).
-- (planned) Namespace awareness and `xs:import` support. Closes #10.
+- Namespace awareness: schemas with a `targetNamespace` resolve by namespace
+  URI (builtins detected by URI, not the `xs` prefix), the XML targets emit the
+  correct `xmlns`/prefix declarations, and `xs:import` resolves types across
+  namespaces (contrast `xs:include`'s same-namespace merge). Cyclic schemas are
+  rejected instead of overflowing the stack. Closes #10.
 - (planned) Prebuilt binary releases (Linux/macOS), Homebrew formula, Docker image.
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,8 +369,11 @@ if(MSVC)
   set(_incbin_data "${CMAKE_BINARY_DIR}/generated/luascript_data.c")
   add_custom_command(
     OUTPUT "${_incbin_data}"
+    # incbin's arg parser only accepts the glued -Ipath form (a bare -I
+    # registers an empty path and the next token is misread as a source file),
+    # so the include flag must be a single token with no space.
     COMMAND incbin-tool "${CMAKE_CURRENT_SOURCE_DIR}/src/resource.cpp"
-            -I "${CMAKE_CURRENT_SOURCE_DIR}/third-party/incbin"
+            "-I${CMAKE_CURRENT_SOURCE_DIR}/third-party/incbin"
             -o "${_incbin_data}"
     DEPENDS "${LUASCRIPT_LUAC}" incbin-tool
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ set(LIBXSDB_SOURCES
   src/XSDParser/Elements/Enumeration.cpp
   src/XSDParser/Elements/AttributeGroup.cpp
   src/XSDParser/Elements/Include.cpp
+  src/XSDParser/Elements/Import.cpp
   src/XSDParser/Elements/Annotation.cpp
   src/XSDParser/Elements/Documentation.cpp
   src/XSDParser/Elements/All.cpp

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ It processes XSD schema documents and invokes a template file which outputs code
 
 _Look at the Wiki section for more information._
 
-NOTE: Currently the tools are not namespace aware.
+Namespaces are supported: schemas with a `targetNamespace` resolve and the XML
+targets emit the right `xmlns`/prefixes, and `xs:import` brings in types from
+another namespace (`xs:include` continues to merge same-namespace documents).
 
 ### Sample Output ###
 ```

--- a/src/Processors/LuaAdapter.cpp
+++ b/src/Processors/LuaAdapter.cpp
@@ -32,6 +32,8 @@
 #define MAXOCCURS_TAG  "maxOccurs"
 #define MINOCCURS_TAG  "minOccurs"
 #define FACETS_TAG     "facets"
+#define NAMESPACE_TAG  "namespace"
+#define QUALIFIED_TAG  "qualified"
 #define DEBUG_LUASTACK (0)
 
 using namespace std;
@@ -191,6 +193,28 @@ LuaType::Facets(const LuaFacets& rFacets) {
 	luaStackDump_(pLuaState);
 }
 
+void
+LuaType::Namespace(const std::string& rNamespace) {
+	/* only emit when there is a resolved namespace */
+	if (rNamespace.empty())
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* type table is at stack top */
+	lua_pushstring(pLuaState, rNamespace.c_str());
+	lua_setfield(pLuaState, -2, NAMESPACE_TAG);
+}
+
+void
+LuaType::Qualified(bool qualified) {
+	/* only emit when qualified; unqualified is the default */
+	if (!qualified)
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* type table is at stack top */
+	lua_pushboolean(pLuaState, 1);
+	lua_setfield(pLuaState, -2, QUALIFIED_TAG);
+}
+
 /* Class LuaAttribute */
 LuaAttribute::LuaAttribute(	lua_State * pLuaState, 
 							const std::string& rName, 
@@ -257,6 +281,36 @@ LuaAttribute::Facets(const LuaFacets& rFacets) {
 	lua_pop(pLuaState, 2);
 	/* debug */
 	luaStackDump_(pLuaState);
+}
+
+void
+LuaAttribute::Namespace(const std::string& rNamespace) {
+	/* only emit when there is a resolved namespace */
+	if (rNamespace.empty())
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* descend attributes[name] -> [typeName] so the field lands on the type
+	   sub-table (same placement as Facets) */
+	lua_getfield(pLuaState, -1, name_.c_str());
+	lua_getfield(pLuaState, -1, typeName_.c_str());
+	lua_pushstring(pLuaState, rNamespace.c_str());
+	lua_setfield(pLuaState, -2, NAMESPACE_TAG);
+	lua_pop(pLuaState, 2);
+}
+
+void
+LuaAttribute::Qualified(bool qualified) {
+	/* only emit when qualified; unqualified is the default */
+	if (!qualified)
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* descend attributes[name] -> [typeName] so the field lands on the type
+	   sub-table (same placement as Facets) */
+	lua_getfield(pLuaState, -1, name_.c_str());
+	lua_getfield(pLuaState, -1, typeName_.c_str());
+	lua_pushboolean(pLuaState, 1);
+	lua_setfield(pLuaState, -2, QUALIFIED_TAG);
+	lua_pop(pLuaState, 2);
 }
 
 /* virtual */

--- a/src/Processors/LuaAdapter.hpp
+++ b/src/Processors/LuaAdapter.hpp
@@ -108,6 +108,10 @@ namespace Processors {
 		LuaContent * Content();
 		/* attach a `facets` sub-table; no-op when rFacets is empty */
 		void Facets(const LuaFacets& rFacets);
+		/* attach the resolved namespace URI; no-op when rNamespace is empty */
+		void Namespace(const std::string& rNamespace);
+		/* attach the qualified flag; no-op when unqualified (the default) */
+		void Qualified(bool qualified);
 	protected:
 		LuaType(lua_State * pLuaState, const std::string& rTypeName,
 		        const int maxOccurs, const int minOccurs = 1);
@@ -119,6 +123,10 @@ namespace Processors {
 		virtual ~LuaAttribute();
 		/* attach a `facets` sub-table; no-op when rFacets is empty */
 		void Facets(const LuaFacets& rFacets);
+		/* attach the resolved namespace URI; no-op when rNamespace is empty */
+		void Namespace(const std::string& rNamespace);
+		/* attach the qualified flag; no-op when unqualified (the default) */
+		void Qualified(bool qualified);
 	protected:
 		LuaAttribute(	lua_State * pLuaState,
 						const std::string& rAttribName,

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -119,9 +119,14 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 			/* Default min/maxOccurs is 1 */
 			int maxOccurs = pNode->HasMaxOccurs() ?	pNode->MaxOccurs() : 1;
 			int minOccurs = pNode->HasMinOccurs() ?	pNode->MinOccurs() : 1;
-			LuaProcessor luaPrcssr(
-				pLuaContent->Type(pNode->Name(), maxOccurs, minOccurs));
+			LuaType * pLuaType =
+				pLuaContent->Type(pNode->Name(), maxOccurs, minOccurs);
+			LuaProcessor luaPrcssr(pLuaType);
 			luaPrcssr.activePath_ = activePath_;
+			/* element namespace/form land on the element's type table before
+			   parseType_ descends into the content sub-tables */
+			pLuaType->Namespace(pNode->Namespace());
+			pLuaType->Qualified(pNode->Qualified());
 			luaPrcssr.parseType_(*pElmType);
 		}
 	} else {
@@ -248,6 +253,9 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		walkAttributeFacets_(pType.get());
 		pAttribute->Facets(facets_);
 		facets_.clear();
+		/* attribute namespace/form, gated like facets */
+		pAttribute->Namespace(pNode->Namespace());
+		pAttribute->Qualified(pNode->Qualified());
 	}
 }
 

--- a/src/XSDParser/Elements/Attribute.cpp
+++ b/src/XSDParser/Elements/Attribute.cpp
@@ -109,6 +109,23 @@ Attribute::Type() const noexcept(false) {
 }
 
 std::string
+Attribute::Namespace() const noexcept(false) {
+	std::unique_ptr<Schema> pSchema(Node::GetSchema());
+	return pSchema->TargetNamespace();
+}
+
+bool
+Attribute::Qualified() const noexcept(false) {
+	/* a local form= attribute overrides the schema's attributeFormDefault */
+	if (Node::HasAttribute("form"))
+		return "qualified" == Node::GetAttribute<std::string>("form");
+	std::unique_ptr<Schema> pSchema(Node::GetSchema());
+	const char* pVal =
+		pSchema->GetXMLElm().Attribute("attributeFormDefault");
+	return pVal && 0 == strcmp(pVal, "qualified");
+}
+
+std::string
 Attribute::Default() const noexcept(false) {
 	return std::string(Node::GetAttribute<const char*>("default"));
 }

--- a/src/XSDParser/Elements/Attribute.hpp
+++ b/src/XSDParser/Elements/Attribute.hpp
@@ -52,6 +52,10 @@ namespace XSD {
 			std::string Name() const noexcept(false);;
 			Attribute* RefAttribute() const noexcept(false);;
 			Types::BaseType* Type() const noexcept(false);;
+			/* Owning schema's targetNamespace URI; "" if none. */
+			std::string Namespace() const noexcept(false);
+			/* Qualified? local form= else attributeFormDefault; default false. */
+			bool Qualified() const noexcept(false);
 			std::string Default() const noexcept(false);;
 			std::string Fixed() const noexcept(false);;
 			AttributeUse Use() const noexcept(false);;

--- a/src/XSDParser/Elements/Element.cpp
+++ b/src/XSDParser/Elements/Element.cpp
@@ -30,6 +30,7 @@
 #include <tinyxml.h>
 #include "./src/XSDParser/Types.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
+#include "./src/XSDParser/Elements/Schema.hpp"
 #include "./src/XSDParser/Elements/SimpleType.hpp"
 #include "./src/XSDParser/Elements/ComplexType.hpp"
 #include "./src/XSDParser/Elements/Annotation.hpp"
@@ -133,6 +134,23 @@ Element::Type() const noexcept(false) {
 	} else {
 		return ParseType_(*this);
 	}
+}
+
+std::string
+Element::Namespace() const noexcept(false) {
+	std::unique_ptr<Schema> pSchema(Node::GetSchema());
+	return pSchema->TargetNamespace();
+}
+
+bool
+Element::Qualified() const noexcept(false) {
+	/* a local form= attribute overrides the schema's elementFormDefault */
+	if (Node::HasAttribute("form"))
+		return "qualified" == Node::GetAttribute<std::string>("form");
+	std::unique_ptr<Schema> pSchema(Node::GetSchema());
+	const char* pVal =
+		pSchema->GetXMLElm().Attribute("elementFormDefault");
+	return pVal && 0 == strcmp(pVal, "qualified");
 }
 
 Element*

--- a/src/XSDParser/Elements/Element.hpp
+++ b/src/XSDParser/Elements/Element.hpp
@@ -50,6 +50,10 @@ namespace XSD {
 			Element* SubstitutionGroup() const noexcept(false);;
 			bool VerifySubstitutionGroup() const noexcept(false);;
 			Types::BaseType* Type() const noexcept(false);;
+			/* Owning schema's targetNamespace URI; "" if none. */
+			std::string Namespace() const noexcept(false);
+			/* Qualified? local form= else elementFormDefault; default false. */
+			bool Qualified() const noexcept(false);
 			Element* RefElement() const noexcept(false);;
 			int MaxOccurs() const;
 			int MinOccurs() const;

--- a/src/XSDParser/Elements/Import.cpp
+++ b/src/XSDParser/Elements/Import.cpp
@@ -1,9 +1,9 @@
 /*
- * Include.cpp
+ * Import.cpp
  *
- *  Created on: Aug 10, 2011
+ *  Created on: Jun 25, 2026
  *      Author: QVXLabs LLC
- *   Copyright: (c)2011 QVXLabs LLC
+ *   Copyright: (c)2026 QVXLabs LLC
  *
  *  This file is part of xsd-tools.
  *
@@ -23,7 +23,7 @@
 
 #include <memory>
 #include <unistd.h>
-#include "./src/XSDParser/Elements/Include.hpp"
+#include "./src/XSDParser/Elements/Import.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"
 #include "./src/XSDParser/Elements/Annotation.hpp"
@@ -32,33 +32,42 @@
 using namespace XSD;
 using namespace XSD::Elements;
 
-Include::Include(const TiXmlElement& elm, const Parser& rParser)
+Import::Import(const TiXmlElement& elm, const Parser& rParser)
 	: Node(elm, rParser), pSchema_(NULL)
 { }
 
-Include::Include(const Include& rCpy)
+Import::Import(const Import& rCpy)
 	: Node(rCpy), pSchema_(rCpy.pSchema_)
 { }
 
 /* virtual */
-Include::~Include() {
+Import::~Import() {
 	delete pSchema_;
 }
 
 void
-Include::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
+Import::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	/* does nothing, doesn't have child elements */
 }
 
 void
-Include::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
-	rProcessor.ProcessInclude(this);
+Import::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
+	rProcessor.ProcessImport(this);
 }
 
 const Schema*
-Include::QuerySchema() const noexcept(false) {
-	if (NULL == pSchema_) {
-		pSchema_ = Node::GetParser().Parse(resolveSchemaURI_("schemaLocation"));
+Import::QuerySchema() const noexcept(false) {
+	if (NULL == pSchema_ && HasSchema()) {
+		std::string uri = resolveSchemaURI_("schemaLocation");
+		pSchema_ = Node::GetParser().Parse(uri);
+		/* index the imported namespace so cross-doc refs resolve by URI */
+		Node::GetParser().RegisterNamespace(pSchema_->TargetNamespace(), uri);
 	}
 	return pSchema_;
+}
+
+std::string
+Import::ImportNamespace() const noexcept {
+	return HasNamespace()
+		? std::string(GetXMLElm().Attribute("namespace")) : std::string("");
 }

--- a/src/XSDParser/Elements/Import.hpp
+++ b/src/XSDParser/Elements/Import.hpp
@@ -1,9 +1,9 @@
 /*
- * Include.hpp
+ * Import.hpp
  *
- *  Created on: Aug 10, 2011
+ *  Created on: Jun 25, 2026
  *      Author: QVXLabs LLC
- *   Copyright: (c)2011 QVXLabs LLC
+ *   Copyright: (c)2026 QVXLabs LLC
  *
  *  This file is part of xsd-tools.
  *
@@ -21,8 +21,8 @@
  *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef INCLUDE_HPP_
-#define INCLUDE_HPP_
+#ifndef IMPORT_HPP_
+#define IMPORT_HPP_
 #ifndef TIXML_USE_STL
 #	define TIXML_USE_STL
 #endif /* TIXML_USE_STL */
@@ -33,21 +33,28 @@
 
 namespace XSD {
 	namespace Elements {
-		class Include : public Node {
-			XSD_ELEMENT_TAG("include")
+		/* xs:import brings in a DIFFERENT-namespace schema; unlike xs:include
+		 * (a same-namespace merge) the loaded document keeps its own target
+		 * namespace, registered against the importing Parser. */
+		class Import : public Node {
+			XSD_ELEMENT_TAG("import")
 		private:
 			mutable Schema*	pSchema_;
-			Include();
+			Import();
 		public:
-			Include(const TiXmlElement& elm, const Parser& rParser);
-			Include(const Include& elm);
-			virtual ~Include();
-			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);;
-			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);;
-			const Schema* QuerySchema() const noexcept(false);;
+			Import(const TiXmlElement& elm, const Parser& rParser);
+			Import(const Import& elm);
+			virtual ~Import();
+			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
+			/* The imported document's schema; NULL if no schemaLocation. */
+			const Schema* QuerySchema() const noexcept(false);
+			/* The declared import namespace attr value ("" if absent). */
+			std::string ImportNamespace() const noexcept;
+			XSD_HAS_ATTR(HasNamespace, "namespace")
 			XSD_HAS_ATTR(HasSchema, "schemaLocation")
 		};
 	}	/* namespace Elements */
 }	/* namespace XSD */
 
-#endif /* INCLUDE_HPP_ */
+#endif /* IMPORT_HPP_ */

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string.h>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
 #include "./src/XSDParser/Elements/Node.hpp"
 #include "./src/XSDParser/Elements/Attribute.hpp"
 #include "./src/XSDParser/Elements/Choice.hpp"
@@ -54,6 +55,7 @@
 #include "./src/XSDParser/Elements/WhiteSpace.hpp"
 #include "./src/XSDParser/Elements/AttributeGroup.hpp"
 #include "./src/XSDParser/Elements/Include.hpp"
+#include "./src/XSDParser/Elements/Import.hpp"
 #include "./src/XSDParser/Elements/Annotation.hpp"
 #include "./src/XSDParser/Elements/Documentation.hpp"
 #include "./src/XSDParser/Elements/All.hpp"
@@ -228,6 +230,9 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 		{ Include::XSDTag(),
 			[](const TiXmlElement& e, const Parser& p) -> Node*
 				{ return new Include(e, p); } },
+		{ Import::XSDTag(),
+			[](const TiXmlElement& e, const Parser& p) -> Node*
+				{ return new Import(e, p); } },
 		{ Annotation::XSDTag(),
 			[](const TiXmlElement& e, const Parser& p) -> Node*
 				{ return new Annotation(e, p); } },
@@ -261,7 +266,7 @@ Node::FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(f
 		(pSchemaRoot->TargetNamespace() == rName.ns)
 			? pSchemaRoot->FindChildXMLElement_(elementName.c_str(), "name", pLocal)
 			: NULL;
-	/* search all included documents */
+	/* search all included documents (same-namespace merge) */
 	if (!pElm) {
 		const TiXmlElement* pIncludElm = pSchemaRoot->GetXMLElm().FirstChildElement(XSD::Elements::Include::XSDTag());
 		for ( ; pIncludElm; pIncludElm = pIncludElm->NextSiblingElement(XSD::Elements::Include::XSDTag()) ) {
@@ -276,7 +281,33 @@ Node::FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(f
 		}
 	} else
 		pRetNode = ConstructNode_(pElm, rParser_);
+	/* cross-namespace reference: resolve against an xs:import whose loaded
+	 * target namespace matches rName.ns. The imported doc keeps a distinct
+	 * namespace, unlike xs:include's same-namespace merge above. */
+	if (!pRetNode)
+		pRetNode = FindImportedXSDElm_(rName, pTypeName);
 	return pRetNode;
+}
+
+Node*
+Node::FindImportedXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(false) {
+	const char* pLocal = rName.local.c_str();
+	std::unique_ptr<Schema> pSchemaRoot(GetSchema());
+	std::string importTag = QualifyElementName(XSD::Elements::Import::XSDTag());
+	const TiXmlElement* pImportElm = pSchemaRoot->GetXMLElm().FirstChildElement(importTag.c_str());
+	for ( ; pImportElm; pImportElm = pImportElm->NextSiblingElement(importTag.c_str()) ) {
+		std::unique_ptr<Import> pNode(static_cast<Import*>(ConstructNode_(pImportElm, rParser_)));
+		const Schema* pSchema = pNode->QuerySchema();
+		if (NULL == pSchema || pSchema->TargetNamespace() != rName.ns)
+			continue;
+		/* qualify the type tag against the imported doc's own XSD-lang prefix */
+		std::string elementName = pSchema->QualifyElementName(pTypeName);
+		const TiXmlElement* pElm =
+			pSchema->FindChildXMLElement_(elementName.c_str(), "name", pLocal);
+		if (NULL != pElm)
+			return ConstructNode_(pElm, pSchema->rParser_);
+	}
+	return NULL;
 }
 
 Node*
@@ -524,9 +555,52 @@ Node::QualifyElementName(const char* pElemName) const throw() {
 	return elementName;
 }
 
-const TiXmlDocument& 
+const TiXmlDocument&
 Node::GetXmlDocument() const {
 	const TiXmlNode * pNode = &rXmlElm_;
 	for (; pNode->Parent(); pNode = pNode->Parent()) {}
 	return *(pNode->ToDocument());
+}
+
+/* Shared schemaLocation -> loadable-URI resolution for xs:include/xs:import. */
+namespace {
+	std::string extractURIPath_(const std::string& uri) {
+		std::string noQuery = uri.substr(0, uri.find("?"));
+		const size_t protoNdx = noQuery.find("://");
+		return noQuery.substr(
+			(std::string::npos == protoNdx) ? 0 : protoNdx + 3);
+	}
+	bool isFileURI_(const std::string& uri) {
+		std::string noQuery = uri.substr(0, uri.find("?"));
+		bool hasFileProto = (std::string::npos != noQuery.find("file://"));
+		bool hasProto = (std::string::npos != noQuery.find("://"));
+		return (hasFileProto || !hasProto);
+	}
+	std::string extractQuery_(const std::string& uri) {
+		const size_t queryNdx = uri.find("?");
+		return (std::string::npos == queryNdx)
+			? std::string("") : uri.substr(queryNdx);
+	}
+}
+
+std::string
+Node::resolveSchemaURI_(const char* pAttrib) const noexcept(false) {
+	std::string uri(GetAttribute<const char*>(pAttrib));
+	if (!isFileURI_(uri))
+		return uri;
+	std::string retStr("file://");
+	boost::filesystem::path path(extractURIPath_(uri));
+	if (path.has_root_path()) {
+		retStr += (path.string() + extractQuery_(uri));
+		return retStr;
+	}
+	std::unique_ptr<Schema> pDocRoot(GetSchema());
+#if defined(BOOST_FILESYSTEM_VERSION) && (BOOST_FILESYSTEM_VERSION > 2)
+	boost::filesystem::path schemaPath = (boost::filesystem::absolute(extractURIPath_(pDocRoot->URI()))).branch_path();
+#else
+	boost::filesystem::path schemaPath = (boost::filesystem::complete(extractURIPath_(pDocRoot->URI()))).branch_path();
+#endif
+	(schemaPath /= extractURIPath_(uri)).normalize();
+	retStr += schemaPath.string();
+	return retStr;
 }

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -241,7 +241,7 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 			[](const TiXmlElement& e, const Parser& p) -> Node*
 				{ return new AppInfo(e, p); } },
 	};
-	const std::string elementName = StripNamespace_(pElm->ValueStr());
+	const std::string elementName = stripPrefix_(pElm->ValueStr());
 	for (const auto& rEntry : kTable) {
 		if (boost::iequals(std::string(rEntry.pTag), elementName))
 			return rEntry.pMake(*pElm, rParser);
@@ -251,19 +251,25 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 }
 
 Node*
-Node::FindXSDElm_(const char* pName, const char* pTypeName) const noexcept(false) {
+Node::FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(false) {
 	std::string elementName = QualifyElementName(pTypeName);
+	const char* pLocal = rName.local.c_str();
 	/* search root document */
 	Node* pRetNode = NULL;
 	std::unique_ptr<Schema> pSchemaRoot(GetSchema());
-	const TiXmlElement* pElm = pSchemaRoot->FindChildXMLElement_(elementName.c_str(), "name", pName);
+	const TiXmlElement* pElm =
+		(pSchemaRoot->TargetNamespace() == rName.ns)
+			? pSchemaRoot->FindChildXMLElement_(elementName.c_str(), "name", pLocal)
+			: NULL;
 	/* search all included documents */
 	if (!pElm) {
 		const TiXmlElement* pIncludElm = pSchemaRoot->GetXMLElm().FirstChildElement(XSD::Elements::Include::XSDTag());
 		for ( ; pIncludElm; pIncludElm = pIncludElm->NextSiblingElement(XSD::Elements::Include::XSDTag()) ) {
 			std::unique_ptr<Include> pNode(static_cast<Include*>(ConstructNode_(pIncludElm, rParser_)));
 			const Schema* pSchema = pNode->QuerySchema();
-			if (NULL != (pElm = pSchema->FindChildXMLElement_(elementName.c_str(), "name", pName))) {
+			if (pSchema->TargetNamespace() != rName.ns)
+				continue;
+			if (NULL != (pElm = pSchema->FindChildXMLElement_(elementName.c_str(), "name", pLocal))) {
 				pRetNode = ConstructNode_(pElm, pSchema->rParser_);
 				break;
 			}
@@ -274,8 +280,8 @@ Node::FindXSDElm_(const char* pName, const char* pTypeName) const noexcept(false
 }
 
 Node*
-Node::FindXSDNode_(const char* pName, const char* pTypeName) const noexcept(false) {
-	Node* pNode = FindXSDElm_(pName, pTypeName);
+Node::FindXSDNode_(const XsdQName& rName, const char* pTypeName) const noexcept(false) {
+	Node* pNode = FindXSDElm_(rName, pTypeName);
 	if (!pNode)
 		throw XMLException(rXmlElm_, XMLException::MissingElement);
 	return pNode;
@@ -294,7 +300,8 @@ Node::FindChildXSDNode_(const char* pXMLTag) const noexcept(false) {
 Node*
 Node::FindXSDRef_(const char* pRefAttribStr, const char* pTypeName) const noexcept(false) {
 	if (HasAttribute(pRefAttribStr)) {
-		std::unique_ptr<Node> pRefElm(FindXSDNode_(GetAttribute<const char*>(pRefAttribStr), pTypeName));
+		XsdQName ref = ResolveQName_(GetAttribute<const char*>(pRefAttribStr));
+		std::unique_ptr<Node> pRefElm(FindXSDNode_(ref, pTypeName));
 		return pRefElm->FindXSDRef_(pRefAttribStr, pTypeName);
 	} else
 		return ConstructNode_(&rXmlElm_, rParser_);
@@ -311,36 +318,48 @@ Node::Attribute_(const char* pAttrib) const noexcept(false) {
 
 Types::BaseType*
 Node::Type_(const char* pType) const noexcept(false) {
-	/* search for type name */
-	std::string typeName = StripNamespace_(std::string(pType));
-	Types::BaseType* pRetType = rParser_.QueryTypesDb().FindType(typeName.c_str());
-	if (typeid(*pRetType) == typeid(Types::Unknown)) {
-		delete pRetType;
-		Node* pSimpleType = FindXSDElm_(typeName.c_str(), SimpleType::XSDTag());
-		if (NULL != pSimpleType)
-			return new Types::SimpleType(static_cast<SimpleType*>(pSimpleType));
-		Node* pComplexType = FindXSDElm_(typeName.c_str(), ComplexType::XSDTag());
-		if (NULL != pComplexType)
-			return new Types::ComplexType(
-				static_cast<ComplexType*>(pComplexType));
-		throw XMLException(rXmlElm_, XMLException::MissingElement);
-	}
-	return pRetType;
+	return Type_(ResolveQName_(std::string(pType)));
 }
 
-const std::string 
-Node::StripNamespace_(const std::string& rQName) const noexcept(false) {
-	std::unique_ptr<Schema> pSchema(GetSchema());
-	std::string xmlNamespace = pSchema->Namespace();
-	/* verify that the namespace is in the qualified name */
-	if (0 == rQName.find(xmlNamespace)) {
-		if (xmlNamespace.length() > 0) {
-			return rQName.substr(xmlNamespace.length() + 1);
-		} else {
-			return rQName;
-		}
+Types::BaseType*
+Node::Type_(const XsdQName& rName) const noexcept(false) {
+	/* Builtins are detected by namespace URI, not by the "xs" prefix.
+	 * TypesDB stays keyed by bare local name. An empty ns (a schema that
+	 * declares no namespace at all) also probes builtins, preserving the
+	 * legacy bare-name lookup. */
+	if (rName.ns == XSD_NS || rName.ns.empty()) {
+		Types::BaseType* pBuiltin =
+			rParser_.QueryTypesDb().FindType(rName.local.c_str());
+		if (typeid(*pBuiltin) != typeid(Types::Unknown))
+			return pBuiltin;
+		delete pBuiltin;
 	}
-	return rQName;
+	/* user-defined type search */
+	Node* pSimpleType = FindXSDElm_(rName, SimpleType::XSDTag());
+	if (NULL != pSimpleType)
+		return new Types::SimpleType(static_cast<SimpleType*>(pSimpleType));
+	Node* pComplexType = FindXSDElm_(rName, ComplexType::XSDTag());
+	if (NULL != pComplexType)
+		return new Types::ComplexType(
+			static_cast<ComplexType*>(pComplexType));
+	throw XMLException(rXmlElm_, XMLException::MissingElement);
+}
+
+/* static */ std::string
+Node::stripPrefix_(const std::string& rQName) noexcept {
+	const size_t ndx = rQName.find(":");
+	return (std::string::npos == ndx) ? rQName : rQName.substr(ndx + 1);
+}
+
+XsdQName
+Node::ResolveQName_(const std::string& rRaw) const noexcept(false) {
+	std::unique_ptr<Schema> pSchema(GetSchema());
+	const size_t ndx = rRaw.find(":");
+	std::string prefix = (std::string::npos == ndx)
+		? std::string("") : rRaw.substr(0, ndx);
+	std::string local = (std::string::npos == ndx)
+		? rRaw : rRaw.substr(ndx + 1);
+	return XsdQName{ pSchema->ResolvePrefix(prefix), local };
 }
 
 Node*

--- a/src/XSDParser/Elements/Node.hpp
+++ b/src/XSDParser/Elements/Node.hpp
@@ -61,6 +61,9 @@ namespace XSD {
 			const TiXmlElement* ContentElement(const char* pElemName) const noexcept(false);
 			const TiXmlElement* FindChildXMLElement_(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false);
 			Node* FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(false);
+			/* Cross-namespace resolution: search xs:import'ed documents whose
+			 * loaded target namespace matches rName.ns. NULL if none match. */
+			Node* FindImportedXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(false);
 			Node* ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const;
 			Node* FindXSDNode_(const XsdQName& rName, const char* pTypeName) const noexcept(false);
 			Node* FindChildXSDNode_(const char* pXMLTag) const noexcept(false);
@@ -99,6 +102,11 @@ namespace XSD {
 			/* The "name" attribute as a string; shared by named nodes. */
 			std::string name_() const noexcept(false);
 			std::string QualifyElementName(const char* pElemName) const noexcept;
+			/* Resolve a schemaLocation-style attribute to a loadable URI,
+			 * making relative file paths absolute against this document.
+			 * Shared by xs:include and xs:import. */
+			std::string resolveSchemaURI_(const char* pAttrib)
+				const noexcept(false);
 			template<typename T> T GetAttribute(const char* pAttrib) const noexcept(false) {
 				T retVal;
 				std::stringstream sstrm(Attribute_(pAttrib));

--- a/src/XSDParser/Elements/Node.hpp
+++ b/src/XSDParser/Elements/Node.hpp
@@ -36,6 +36,7 @@
 #include "./src/XSDParser/Types.hpp"
 #include "./src/XSDParser/Parser.hpp"
 #include "./src/XSDParser/ProcessorBase.hpp"
+#include "./src/XSDParser/XsdQName.hpp"
 
 #define XSD_ISELEMENT(TYPE_PTR,TYPE)	typeid(*TYPE_PTR) == typeid(TYPE)
 #define XSD_ELEMENT_TAG(NAME)			public: static const char* XSDTag() throw() { return NAME; }
@@ -59,16 +60,24 @@ namespace XSD {
 			Node();
 			const TiXmlElement* ContentElement(const char* pElemName) const noexcept(false);
 			const TiXmlElement* FindChildXMLElement_(const char* pXMLElmTag, const char* pAttrib, const char* pName) const noexcept(false);
-			Node* FindXSDElm_(const char* pName, const char* pTypeName) const noexcept(false);
+			Node* FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(false);
 			Node* ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const;
-			Node* FindXSDNode_(const char* pName, const char* pTypeName) const noexcept(false);
+			Node* FindXSDNode_(const XsdQName& rName, const char* pTypeName) const noexcept(false);
 			Node* FindChildXSDNode_(const char* pXMLTag) const noexcept(false);
 			Node* FindXSDRef_(const char* pRefAttribStr, const char* pTypeName) const noexcept(false);
 			std::string Attribute_(const char* pAttrib) const noexcept(false);
-			const std::string StripNamespace_(const std::string& rQName) const noexcept(false);
+			/* Pure syntactic prefix strip (prefix:local -> local); used by the
+			 * ConstructNode_ tag dispatch. NOT a resolution step. */
+			static std::string stripPrefix_(const std::string& rQName) noexcept;
+			/* Resolve a raw "prefix:local" into a namespace-aware XsdQName via
+			 * the owning Schema's xmlns declarations. No-prefix maps through
+			 * the default xmlns URI (may be XSD_NS, the target NS, or ""). */
+			XsdQName ResolveQName_(const std::string& rRaw) const noexcept(false);
 		protected:
 			Node(const TiXmlElement& elm, const Parser& rParser);
 			Node(const Node& rCpy);
+			Types::BaseType* Type_(const XsdQName& rName) const noexcept(false);
+			/* Convenience overload: resolve a raw QName string then dispatch. */
 			Types::BaseType* Type_(const char* pType) const noexcept(false);
 			/* QueryRootElement(): returns the root element of the document containg the node*/
 			const TiXmlElement& QueryRootElement() const;
@@ -97,7 +106,7 @@ namespace XSD {
 				return retVal;
 			}
 			template<typename T> T* FindXSDElm(const char* pName) const noexcept(false) {
-				return static_cast<T*>(FindXSDNode_(pName, T::XSDTag()));
+				return static_cast<T*>(FindXSDNode_(ResolveQName_(pName), T::XSDTag()));
 			}
 			template<typename T> T* FindXSDRef(const char* pRefAttribStr) const noexcept(false) {
 				return static_cast<T*>(FindXSDRef_(pRefAttribStr, T::XSDTag()));

--- a/src/XSDParser/Elements/Schema.cpp
+++ b/src/XSDParser/Elements/Schema.cpp
@@ -28,6 +28,7 @@
 #include "./src/XSDParser/Elements/Schema.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Include.hpp"
+#include "./src/XSDParser/Elements/Import.hpp"
 #include "./src/XSDParser/Elements/Annotation.hpp"
 
 using namespace XSD;
@@ -51,7 +52,8 @@ Schema::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, Element) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
-			XSD_ISELEMENT(&rNode, Include)) {
+			XSD_ISELEMENT(&rNode, Include) ||
+			XSD_ISELEMENT(&rNode, Import)) {
 			rNode.ParseElement(rProcessor);
 		}
 	});

--- a/src/XSDParser/Elements/Schema.cpp
+++ b/src/XSDParser/Elements/Schema.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <tinyxml.h>
 #include "./src/util.hpp"
+#include "./src/XSDParser/XsdQName.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Include.hpp"
@@ -71,12 +72,31 @@ Schema::URI() const noexcept(false) {
 	return documentURI_;
 }
 
+Schema::PrefixMap
+Schema::prefixMap_() const noexcept(false) {
+	/* Built off the live root element each call. A process-static cache keyed
+	 * on TiXmlDocument* is unsafe: freed documents recycle their address, so
+	 * stale entries leak across parses. The scan is a handful of attrs. */
+	PrefixMap map;
+	for (const TiXmlAttribute* pAttrib = Node::GetXMLElm().FirstAttribute();
+			pAttrib; pAttrib = pAttrib->Next()) {
+		std::string name(pAttrib->Name());
+		if (name == "xmlns")
+			map[std::string("")] = pAttrib->Value();
+		else if (0 == name.find("xmlns:"))
+			map[name.substr(name.find(":") + 1)] = pAttrib->Value();
+	}
+	return map;
+}
+
 const std::string
 Schema::Namespace() const noexcept(false) {
-	/* search for xmlns attribute (sans the namespace prefix) */
+	/* The prefix whose URI is the XSD-lang namespace; preserves the legacy
+	 * first-match-in-document-order, substring-match semantics so the tag
+	 * prefix ("xs"/"") that QualifyElementName prepends stays byte-identical. */
 	const TiXmlAttribute * pAttrib = Node::GetXMLElm().FirstAttribute();
-	for ( ; pAttrib && (std::string::npos == std::string(pAttrib->Value()).find("http://www.w3.org/2001/XMLSchema"));
-			pAttrib = pAttrib->Next()) { 
+	for ( ; pAttrib && (std::string::npos == std::string(pAttrib->Value()).find(XSD_NS));
+			pAttrib = pAttrib->Next()) {
 	}
 	/* extract the namespace prefix if attribute found */
 	if (pAttrib) {
@@ -84,6 +104,19 @@ Schema::Namespace() const noexcept(false) {
 		return attribName.substr(attribName.find(":") + 1);
 	}
 	return std::string("");
+}
+
+std::string
+Schema::TargetNamespace() const noexcept(false) {
+	const char* pVal = Node::GetXMLElm().Attribute("targetNamespace");
+	return pVal ? std::string(pVal) : std::string("");
+}
+
+std::string
+Schema::ResolvePrefix(const std::string& rPrefix) const noexcept(false) {
+	PrefixMap map = prefixMap_();
+	PrefixMap::const_iterator it = map.find(rPrefix);
+	return (it != map.end()) ? it->second : std::string("");
 }
 
 Types::BaseType * 

--- a/src/XSDParser/Elements/Schema.hpp
+++ b/src/XSDParser/Elements/Schema.hpp
@@ -26,6 +26,7 @@
 #ifndef TIXML_USE_STL
 #	define TIXML_USE_STL
 #endif /* TIXML_USE_STL */
+#include <map>
 #include <string>
 #include <tinyxml.h>
 #include "./src/XSDParser/Exception.hpp"
@@ -36,9 +37,13 @@ namespace XSD {
 		class Schema : public Node {
 			XSD_ELEMENT_TAG("schema")
 		private:
+			typedef std::map<std::string, std::string> PrefixMap;
 			std::string		documentURI_;
 			Schema();
-			static std::string extractName_(const std::string& uri);			
+			static std::string extractName_(const std::string& uri);
+			/* prefix->URI map off this document's root element; empty key is
+			 * the default (xmlns) namespace. */
+			PrefixMap prefixMap_() const noexcept(false);
 		public:
 			Schema(const TiXmlElement& elm, const Parser& rParser, const std::string& uri);
 			Schema( const Schema& elm);
@@ -48,6 +53,12 @@ namespace XSD {
 			const std::string Name() const noexcept(false);
 			const std::string& URI() const noexcept(false);
 			const std::string Namespace() const noexcept(false);
+			/* targetNamespace attr value; "" when absent. */
+			std::string TargetNamespace() const noexcept(false);
+			/* Resolve a namespace prefix to its URI via the root xmlns:* attrs;
+			 * empty prefix resolves the default xmlns. "" when undeclared. */
+			std::string ResolvePrefix(const std::string& rPrefix)
+				const noexcept(false);
 			Types::BaseType * GetParentType() const noexcept(false);
 			bool isRootSchema() const;
 		};

--- a/src/XSDParser/Parser.cpp
+++ b/src/XSDParser/Parser.cpp
@@ -29,7 +29,7 @@
 using namespace XSD;
 
 Parser::Parser()
-  : typesDb_(), docLst_()
+  : typesDb_(), docLst_(), nsIndex_()
 { }
 
 /* virtual */
@@ -118,8 +118,22 @@ Parser::GetDocument(const std::string& rUri) const {
 	return pRec ? pRec->pDocument_ : NULL;
 }
 
-bool 
+bool
 Parser::isRootDocument(const TiXmlDocument& document) const {
 	return ((*(docLst_.begin()))->pDocument_ == &document);
+}
+
+void
+Parser::RegisterNamespace(const std::string& rNamespace,
+		const std::string& rUri) const {
+	if (!rNamespace.empty())
+		nsIndex_[rNamespace] = rUri;
+}
+
+std::string
+Parser::GetNamespaceUri(const std::string& rNamespace) const {
+	std::map<std::string, std::string>::const_iterator it =
+		nsIndex_.find(rNamespace);
+	return (it != nsIndex_.end()) ? it->second : std::string("");
 }
 

--- a/src/XSDParser/Parser.hpp
+++ b/src/XSDParser/Parser.hpp
@@ -23,6 +23,7 @@
 #ifndef PARSER_HPP_
 #define PARSER_HPP_
 
+#include <map>
 #include <string>
 #include <vector>
 #include "./src/XSDParser/TypesDB.hpp"
@@ -47,6 +48,8 @@ namespace XSD {
 		typedef std::vector<DocumentRecord *> XmlDocList;
 		Types::TypesDB 		typesDb_;
 	    mutable XmlDocList	docLst_;
+		/* xs:import index: imported targetNamespace URI -> document URI. */
+		mutable std::map<std::string, std::string> nsIndex_;
 		DocumentRecord* findByUri_(const std::string& rUri) const;
 		DocumentRecord* findByDoc_(const TiXmlDocument& document) const;
 	public:
@@ -60,6 +63,11 @@ namespace XSD {
 		std::string GetUri(const TiXmlDocument& document) const;
 		const TiXmlDocument * GetDocument(const std::string& rUri) const;
 		bool isRootDocument(const TiXmlDocument& document) const;
+		/* Record an xs:import: map its targetNamespace URI to the loaded doc. */
+		void RegisterNamespace(const std::string& rNamespace,
+			const std::string& rUri) const;
+		/* The document URI registered for an imported namespace ("" if none). */
+		std::string GetNamespaceUri(const std::string& rNamespace) const;
 	};
 }	/* namespace XSD */
 

--- a/src/XSDParser/ProcessorBase.hpp
+++ b/src/XSDParser/ProcessorBase.hpp
@@ -55,6 +55,7 @@ namespace XSD {
 		class WhiteSpace;
 		class AttributeGroup;
 		class Include;
+		class Import;
 		class Annotation;
 		class Documentation;
 		class All;
@@ -92,6 +93,9 @@ namespace XSD {
 		virtual void ProcessWhiteSpace(const Elements::WhiteSpace* pNode) = 0;
 		virtual void ProcessAttributeGroup(const Elements::AttributeGroup* pNode) = 0;
 		virtual void ProcessInclude(const Elements::Include* pNode) = 0;
+		/* Non-pure so existing processors need no update; xs:import resolution
+		 * happens lazily in FindXSDElm_, so the default visit is a no-op. */
+		virtual void ProcessImport(const Elements::Import* pNode) {}
 		virtual void ProcessAnnotation(const Elements::Annotation* pNode) = 0;
 		virtual void ProcessDocumentation(const Elements::Documentation* pNode) = 0;
 		virtual void ProcessAll(const Elements::All* pNode) = 0;

--- a/src/XSDParser/XsdQName.hpp
+++ b/src/XSDParser/XsdQName.hpp
@@ -1,0 +1,43 @@
+/*
+ * XsdQName.hpp
+ *
+ *  Created on: Jun 25, 2026
+ *      Author: QVXLabs LLC
+ *   Copyright: (c)2026 QVXLabs LLC
+ *
+ *  This file is part of xsd-tools.
+ *
+ *  xsd-tools is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  xsd-tools is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XSDQNAME_HPP_
+#define XSDQNAME_HPP_
+#include <string>
+
+namespace XSD {
+	/* The XML Schema language namespace URI; builtins live here. Named
+	 * XsdQName (not QName) to avoid clashing with the Types::QName builtin
+	 * under "using namespace XSD::Types;". */
+	constexpr char XSD_NS[] = "http://www.w3.org/2001/XMLSchema";
+
+	struct XsdQName {
+		std::string ns;
+		std::string local;
+		bool operator==(const XsdQName& rOther) const noexcept {
+			return ns == rOther.ns && local == rOther.local;
+		}
+	};
+}	/* namespace XSD */
+
+#endif /* XSDQNAME_HPP_ */

--- a/templates/c-xml-expat
+++ b/templates/c-xml-expat
@@ -1,4 +1,27 @@
-[@lua --include and transform old format
+[@lua --capture namespace info (E3a) before trnsfrm flattens the raw model
+	-- trnsfrm_old drops element-level namespace/qualified, so harvest them from
+	-- the raw element wrappers first, keyed by element name. nsInfo stays empty
+	-- for non-namespaced schemas, gating all NS emission off (byte-identical).
+	nsInfo = {}
+	docRootNS = nil
+	local function harvestNS(name, node)
+		if type(node) ~= 'table' then return end
+		if node.namespace ~= nil or node.qualified ~= nil then
+			nsInfo[name] = { ns = node.namespace, qualified = node.qualified }
+		end
+		table.map(node, function(k, v)
+			if type(v) == 'table' then harvestNS(k, v) end
+		end)
+	end
+	-- top-level keys are the global element(s); the schema target namespace is
+	-- the root element's resolved namespace.
+	table.map(schema, function(k, v)
+		if type(v) == 'table' then
+			harvestNS(k, v)
+			docRootNS = docRootNS or v.namespace
+		end
+	end)
+][@lua --include and transform old format
 	include 'shared/trnsfrm_old'
 	schema = trnsfrm_oldFmt(schema)
 ][@lua --include any shared 'helper' templates
@@ -81,6 +104,28 @@
 			out:append(ind..'\tbreak;\n')
 		end)
 		return out:str()
+	end
+][@lua -- namespace emission helpers (E3a), no-ops when the schema has no
+	-- targetNamespace. Qualified names use a single 'tns' prefix declared on the
+	-- document root; expat's NS-aware parser strips it on unmarshal.
+	nsPrefix = 'tns'
+	docRootName = next(schema.types[schema.root].dependents)
+	-- An element/attribute is emitted with the prefix when its form is qualified
+	-- (XSD elementFormDefault); the global document-root element is always
+	-- qualified when the schema has a target namespace.
+	local function isQualified(name)
+		if not docRootNS then return false end
+		if name == docRootName then return true end
+		local info = nsInfo[name]
+		return info ~= nil and info.qualified == true
+	end
+	-- Prefix a tag/attribute name when qualified, else leave it bare.
+	function nsQualify(name)
+		return isQualified(name) and (nsPrefix..':'..name) or name
+	end
+	-- The xmlns declaration emitted on the document-root start tag (or '').
+	function nsRootDecl()
+		return docRootNS and (' xmlns:'..nsPrefix..'="'..docRootNS..'"') or ''
 	end
 ]/* command to split output: csplit - '/\/\* FILE: /' {*} */
 /* FILE: xml_common.h */
@@ -354,7 +399,7 @@ static int marshal_adjustElmStk_(xml_marshaller* pMarshaller, uint32_t validType
 	table.map(depOrderSansRoot, function(_,node)
 		outbuf:append(table.concat({
 			"\t\tcase ", sdbm_hash(node.name), ":\n",
-			"\t\t\tcstr_appendN_(pMarshaller, pOutStr, ", cLit('</'..node.name..'>'), ");\n",
+			"\t\t\tcstr_appendN_(pMarshaller, pOutStr, ", cLit('</'..nsQualify(node.name)..'>'), ");\n",
 			"\t\t\tbreak;\n",
 		}))
 	end)
@@ -425,20 +470,24 @@ static int marshal_adjustElmStk_(xml_marshaller* pMarshaller, uint32_t validType
 		-- output stack adjustment code to make sure the proper element type is being marshalled
 		local stkfmt = '\tif (!marshal_adjustElmStk_(pMarshaller, %su)) return%s;\n'
 		outbuf:append(stkfmt:format(sdbm_hash(parent.name), next(node.dependents) and ' retFuncs' or ''))
-		-- output start tag (coalesced open + '>' when attribute-free)
+		-- output start tag (coalesced open + '>' when attribute-free). The
+		-- document-root tag carries the xmlns declaration; both are emitted only
+		-- when the schema has a target namespace.
+		local openTag = '<'..nsQualify(node.name)
+			..((node.name == docRootName) and nsRootDecl() or '')
 		if not next(node.attributes) then
 			outbuf:append(table.concat({
-				'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit('<'..node.name..'>'), ');\n'
+				'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit(openTag..'>'), ');\n'
 			}))
 		else
 			outbuf:append(table.concat({
-				'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit('<'..node.name), ');\n'
+				'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit(openTag), ');\n'
 			}))
 			-- output attributes
 			table.map(node.attributes, function(k,v)
 				local attribType = c_narrowCType(v.type, v.facets)
 				outbuf:append(table.concat({
-					'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit(k..'="'), ');\n',
+					'\tcstr_appendN_(pMarshaller, pOutStr, ', cLit(nsQualify(k)..'="'), ');\n',
 					'\t', attribType.binding.marshal.statement('pOutStr', attribType.buildVar('pObj->',k)),
 				}))
 			end)
@@ -568,6 +617,10 @@ static void prsElmRec_init_(xml_prsElmRec* pElmRec, xml_marshaller* pMarshaller,
 		if next(node.attributes) then
 			local attrKeys = {}
 			table.map(node.attributes, function(n, _) attrKeys[#attrKeys+1] = n end)
+			-- Match on the attribute's local name. For a namespaced schema expat
+			-- expands a qualified attr to "uri:local", so strip the prefix; for
+			-- a non-namespaced schema dispatch on *ppAttrs directly (unchanged).
+			local scrut = docRootNS and 'pAttrLocal' or '*ppAttrs'
 			local function attrStmt(name)
 				local a = node.attributes[name]
 				local at = c_narrowCType(a.type, a.facets)
@@ -579,8 +632,12 @@ static void prsElmRec_init_(xml_prsElmRec* pElmRec, xml_marshaller* pMarshaller,
 					..attrStmt(name)..'\t\t\t\tbreak;\n'
 			end
 			body:append('\t\tfor ( ; *ppAttrs ; ppAttrs+=2) {\n')
-			body:append('\t\t\tswitch(SDBMHash_(0, *ppAttrs)) {\n')
-			body:append(sdbmCases('*ppAttrs', attrKeys, attrCase, attrStmt, '\t\t\t'))
+			if docRootNS then
+				body:append('\t\t\tconst char* pAttrLocal = strrchr(*ppAttrs, '
+					..'\':\') ? strrchr(*ppAttrs, \':\') + 1 : *ppAttrs;\n')
+			end
+			body:append('\t\t\tswitch(SDBMHash_(0, '..scrut..')) {\n')
+			body:append(sdbmCases(scrut, attrKeys, attrCase, attrStmt, '\t\t\t'))
 			body:append('\t\t\tdefault:break;\n\t\t\t}\n\t\t}\n')
 		end
 		body:append(table.concat({

--- a/templates/c-xml-expat-dom.template
+++ b/templates/c-xml-expat-dom.template
@@ -1,6 +1,7 @@
 [@lua
 include 'shared/facets'
 include 'c-xml-expat-dom/shared'
+include 'c-xml-expat-dom/namespace'
 include 'c-xml-expat-dom/types'
 include 'c-xml-expat-dom/cstring'
 include 'c-xml-expat-dom/base64'
@@ -140,12 +141,16 @@ function collidingElementNames(XSDDoc)
    local byHash, colliding = {}, {}
    topologicalSort(XSDDoc, function(name, ctype)
       if isSimpleType(ctype._typedef) then return end
-      local h = sdbm_hash(name)
-      if byHash[h] and byHash[h] ~= name then
+      -- Collisions are over the wire tag (prefixed when qualified), since the
+      -- dispatch hashes it; the colliding set stays keyed by the bare local
+      -- name (how the dispatch looks it up).
+      local wire = c_nsTagName(name, ctype._typedef)
+      local h = sdbm_hash(wire)
+      if byHash[h] and byHash[h].wire ~= wire then
          colliding[name] = true
-         colliding[byHash[h]] = true
+         colliding[byHash[h].name] = true
       else
-         byHash[h] = name
+         byHash[h] = { name = name, wire = wire }
       end
    end)
    return colliding
@@ -174,9 +179,9 @@ function outputDclrTypeMthds(name, ctype)
    return str:str()
 end
 
-function outputDefTypeMthds(name, ctype)
+function outputDefTypeMthds(name, ctype, parentName)
    local str = stringBuffer:new()
-   str:append(ctype:defMarshal(name))
+   str:append(ctype:defMarshal(name, parentName == nil))
    str:append("/* ------------ */\n")
    str:append(ctype:defUnmarshal(name))
    str:append("/* ------------ */\n")
@@ -257,9 +262,11 @@ function outputXmlStartElement(XSDDoc)
      XSDDoc,
      function(name, ctype, parentName, parentCType)
         if isSimpleType(ctype._typedef) then return end
-        local elemName = sdbm_hash(name)
+        -- Match the wire tag (prefixed when qualified); bare name otherwise.
+        local wire = c_nsTagName(name, ctype._typedef)
+        local elemName = sdbm_hash(wire)
         local confirm = collisions[name]
-           and (" && !strcmp(pElmName, \"%s\")"):format(name) or ""
+           and (" && !strcmp(pElmName, \"%s\")"):format(wire) or ""
         local parentEnum = parentName and parentCType:typeEnum() or "0"
         if ifCnt == 0 then
            str:append(
@@ -317,9 +324,11 @@ function outputXmlEndElement(XSDDoc)
      XSDDoc,
      function(name, ctype, parentName, parentCType)
         if isSimpleType(ctype._typedef) then return end
-        local elemName = sdbm_hash(name)
+        -- Match the wire tag (prefixed when qualified); bare name otherwise.
+        local wire = c_nsTagName(name, ctype._typedef)
+        local elemName = sdbm_hash(wire)
         local confirm = collisions[name]
-           and (" && !strcmp(pElmName, \"%s\")"):format(name) or ""
+           and (" && !strcmp(pElmName, \"%s\")"):format(wire) or ""
         -- handle first if statment which doesn't use an 'else if'
         if ifCnt == 0 then
            str:append(

--- a/templates/c-xml-expat-dom.template-test
+++ b/templates/c-xml-expat-dom.template-test
@@ -1,6 +1,7 @@
 [@lua
 include 'shared/facets'
 include 'c-xml-expat-dom/shared'
+include 'c-xml-expat-dom/namespace'
 include 'c-xml-expat-dom/types'
 include 'c-xml-expat-dom/cstring'
 include 'c-xml-expat-dom/base64'
@@ -76,7 +77,7 @@ function outputTestXml(XSDDoc)
    local typename, typedef = next(XSDDoc)
    if typename then
       local ctype = ctypes:getType(typedef)
-      out:append(ctype:test(typename))
+      out:append(ctype:test(typename, true))
    end
    return out:str()
 end

--- a/templates/c-xml-expat-dom/complexType
+++ b/templates/c-xml-expat-dom/complexType
@@ -71,39 +71,47 @@ function complexType:dclrDestroy()
       self:typeName(), self:typeName(), self:typeName())
 end
 
-function complexType:defMarshal(elementName)
+function complexType:defMarshal(elementName, isRoot)
+   -- Namespaced output: tag carries its prefix when qualified, and the root
+   -- element binds the xmlns/prefix declaration. Gated on `namespace`, so
+   -- non-namespaced schemas emit the bare tag exactly as before.
+   local tag = c_nsTagName(elementName, self._typedef)
+   local nsDecl = isRoot and c_nsRootDecl(self._typedef) or ""
    out = stringBuffer:new()
    out:append("static void\n")
    out:append(
       ("%s_marshal_(const %s pObj, char ** ppOut, const xml_typeFactory * pFactory) {\n"):format(
      self:typeName(), self:typeName())
    )
-   -- No attributes: coalesce open tag and '>' into one literal append.
-   if table.isEmpty(self._typedef.attributes) then
-      out:append(("  cstr_append_(ppOut, \"<%s>\", pFactory);\n"):format(elementName))
+   -- No attributes (and no ns decl): coalesce open tag and '>' into one append.
+   if table.isEmpty(self._typedef.attributes) and nsDecl == "" then
+      out:append(("  cstr_append_(ppOut, \"<%s>\", pFactory);\n"):format(tag))
    else
-      out:append(("  cstr_append_(ppOut, \"<%s\", pFactory);\n"):format(elementName))
+      out:append(("  cstr_append_(ppOut, \"<%s%s\", pFactory);\n"):format(tag, nsDecl))
       table.map(
          self._typedef.attributes,
          function(atrName, atrTypeTbl)
             local _, atrTypedef = next(atrTypeTbl)
             local atrType = self:_getType(atrTypedef)
+            -- Wire name carries a prefix when the attribute is qualified; the C
+            -- struct field stays the bare local name.
+            local wire = c_nsTagName(atrName, atrTypedef)
             if atrType:inlineScalar() then
                if attrAlwaysPresent(atrTypedef) then
                   out:append(
                      ("  MarshalScalarValue(\"%s\", %s, %s, pObj->%s, ppOut, pFactory);\n")
-                     :format(atrName, atrType:typeName(), atrType:cType(), atrName))
+                     :format(wire, atrType:typeName(), atrType:cType(), atrName))
                else
                   out:append(("  if (pObj->%s) {\n"):format(atrName))
                   out:append(
                      ("    MarshalScalarValue(\"%s\", %s, %s, *pObj->%s, ppOut, pFactory);\n")
-                     :format(atrName, atrType:typeName(), atrType:cType(), atrName))
+                     :format(wire, atrType:typeName(), atrType:cType(), atrName))
                   out:append("  }\n")
                end
             else
                out:append(
                   ("  MarshalAttribute(\"%s\", %s, pObj->%s, ppOut, pFactory);\n"):format(
-                     atrName, atrType:typeName(), atrName)
+                     wire, atrType:typeName(), atrName)
                )
             end
          end
@@ -111,7 +119,7 @@ function complexType:defMarshal(elementName)
       out:append(("  cstr_append_(ppOut, \">\", pFactory);\n"))
    end
    out:append(("  xml_typelist_marshal_(pObj->pContent_, ppOut, pFactory);\n"))
-   out:append(("  cstr_append_(ppOut, \"</%s>\", pFactory);\n"):format(elementName))
+   out:append(("  cstr_append_(ppOut, \"</%s>\", pFactory);\n"):format(tag))
    out:append(("}\n"))
    return out:str()
 end
@@ -128,11 +136,19 @@ function complexType:defUnmarshal(elementName)
      self:typeName(), self:typeName())
    )
    if not table.isEmpty(self._typedef.attributes) then
+      -- Wire name (prefixed when qualified) drives the hash/strcmp dispatch;
+      -- the C struct field keeps the bare local name. Map wire->local so the
+      -- body can recover the field name.
+      local wireName = {}
+      table.map(self._typedef.attributes, function(atrName, atrTypeTbl)
+         local _, atrTypedef = next(atrTypeTbl)
+         wireName[atrName] = c_nsTagName(atrName, atrTypedef)
+      end)
       -- Group by sdbm hash so colliding names share one case (duplicate case
       -- labels won't compile); within a colliding case strcmp-confirm the name.
       local byHash = {}
       table.map(self._typedef.attributes, function(atrName, atrTypeTbl)
-         local h = sdbm_hash(atrName)
+         local h = sdbm_hash(wireName[atrName])
          byHash[h] = byHash[h] or {}
          byHash[h][#byHash[h] + 1] = atrName
       end)
@@ -180,7 +196,8 @@ function complexType:defUnmarshal(elementName)
             out:append(attrBody(names[1], "      "))
          else
             table.map(names, function(_, atrName)
-               out:append(("      if (!strcmp(*ppAttribs, \"%s\")) {\n"):format(atrName))
+               out:append(("      if (!strcmp(*ppAttribs, \"%s\")) {\n"):format(
+                  wireName[atrName]))
                out:append(attrBody(atrName, "        "))
                out:append("      }\n")
             end)
@@ -248,16 +265,21 @@ function complexType:defDestroy()
    return out:str()
 end
 
-function complexType:test(XSDName)
+function complexType:test(XSDName, isRoot)
    local out = stringBuffer:new()
    local attributes = self._typedef.attributes
    local content = self._typedef.content
+   -- Wire tag (prefixed when qualified) + root xmlns/prefix declaration; both
+   -- must mirror the marshaller exactly so the round-trip self-check holds.
+   local tag = c_nsTagName(XSDName, self._typedef)
+   local nsDecl = isRoot and c_nsRootDecl(self._typedef) or ""
    -- attributes
-   local atrLst = {[1]="<"..XSDName}
+   local atrLst = {[1]="<"..tag..nsDecl}
    for atrName, atrTypename, atrTypedef in attrIterator(attributes) do
       local atrType = ctypes:getType(atrTypedef)
       atrLst[#atrLst + 1] =
-         atrName.."=\\\""..atrType:test(atrTypedef.facets).."\\\""
+         c_nsTagName(atrName, atrTypedef).."=\\\""..
+         atrType:test(atrTypedef.facets).."\\\""
     end
     out:append(table.concat(atrLst, " "))
     out:append(">")
@@ -272,7 +294,7 @@ function complexType:test(XSDName)
             out:append(ctype:test(elementName))
          end
       end)
-   out:append(("</%s>"):format(XSDName))
+   out:append(("</%s>"):format(tag))
    return out:str()
 end
 ]

--- a/templates/c-xml-expat-dom/namespace
+++ b/templates/c-xml-expat-dom/namespace
@@ -1,0 +1,64 @@
+[@lua
+-- E3b namespace emission for the DOM target. All behavior is gated on a node's
+-- `namespace` field being present; non-namespaced schemas hit none of this and
+-- emit byte-identical output. Pure functions, mirroring shared/facets.
+
+-- Deterministic prefix for a target-namespace URI. The XSD source prefix is not
+-- in the model, so synthesize a stable one keyed by URI string; the same URI
+-- always maps to the same prefix across marshal/parse/test, keeping the
+-- round-trip self-consistent. Single-target schemas get a single "ns" prefix;
+-- additional URIs (future xs:import) sort by URI for a stable nsN suffix.
+local _nsPrefixCache = nil
+local function _nsPrefixMap()
+   if _nsPrefixCache then return _nsPrefixCache end
+   local uris = {}
+   local function collect(node)
+      if type(node) ~= 'table' then return end
+      if node.namespace then uris[node.namespace] = true end
+      if node.content then
+         table.map(node.content, function(_, child) collect(child) end)
+      end
+      if node.attributes then
+         for _, _, atrTypedef in attrIterator(node.attributes) do
+            collect(atrTypedef)
+         end
+      end
+   end
+   table.map(schema, function(_, v) collect(v) end)
+   local sorted = {}
+   table.map(uris, function(uri, _) sorted[#sorted + 1] = uri end)
+   table.sort(sorted)
+   _nsPrefixCache = {}
+   for i, uri in ipairs(sorted) do
+      _nsPrefixCache[uri] = (#sorted == 1) and "ns" or ("ns" .. i)
+   end
+   return _nsPrefixCache
+end
+
+function c_nsPrefix(uri)
+   return _nsPrefixMap()[uri]
+end
+
+-- Tag name as emitted on the wire: qualified nodes carry a prefix, otherwise
+-- the bare local name (default-ns form, declared via xmlns on the root).
+function c_nsTagName(localName, typedef)
+   if typedef and typedef.namespace and typedef.qualified then
+      return c_nsPrefix(typedef.namespace) .. ":" .. localName
+   end
+   return localName
+end
+
+-- xmlns declaration(s) for a root element's open tag (after "<tag"). Empty when
+-- the root carries no namespace. A qualified root binds its synthesized prefix;
+-- an unqualified root binds the default xmlns to the target URI so its bare
+-- child tags inherit it. Both the marshal body and the -test driver place this
+-- inside a C string literal, so the quotes are backslash-escaped.
+function c_nsRootDecl(typedef)
+   if not (typedef and typedef.namespace) then return "" end
+   if typedef.qualified then
+      return (" xmlns:%s=\\\"%s\\\""):format(
+         c_nsPrefix(typedef.namespace), typedef.namespace)
+   end
+   return (" xmlns=\\\"%s\\\""):format(typedef.namespace)
+end
+]

--- a/templates/java-xml-stax.tmpl
+++ b/templates/java-xml-stax.tmpl
@@ -1,4 +1,33 @@
-[@lua --include and transform old format
+[@lua -- E3d: snapshot element namespace/form BEFORE trnsfrm_old, which drops
+	-- the element-level namespace/qualified fields (carrying them only onto leaf
+	-- content/attributes). Build a name -> {ns, qualified} map and record the
+	-- document's target namespace from the single top-level element. Gated on a
+	-- namespace being present: non-namespaced schemas leave nsByName empty and
+	-- emit byte-identical output.
+	nsByName = {}
+	nsTopLevel = {}
+	local function _nsCollect(name, node)
+		if type(node) ~= 'table' then return end
+		if node.namespace then
+			nsByName[name] = {ns = node.namespace, qualified = node.qualified}
+		end
+		table.map(node.content or {}, function(k, v) _nsCollect(k, v) end)
+	end
+	table.map(schema, function(k, v)
+		if type(v) == 'table' then
+			-- top-level elements are the document roots; only they declare xmlns
+			if v.namespace then nsTopLevel[k] = true end
+			_nsCollect(k, v)
+		end
+	end)
+	-- The document target namespace (single target per schema); nil when absent.
+	docRootNS = nil
+	table.map(nsTopLevel, function(name, _)
+		docRootNS = docRootNS or nsByName[name].ns
+	end)
+	-- Single synthesized prefix for the target NS (the XSD source prefix is not
+	-- in the model); StAX binds it on the root via setPrefix/writeNamespace.
+	nsPrefix = "tns"
 	include 'shared/trnsfrm_old'
 	schema = trnsfrm_oldFmt(schema)
 ][@lua --include any shared 'helper' templates
@@ -21,6 +50,20 @@
 		return v.name ~= schema.root and v or nil end)
 	-- Hex.java is only referenced by scalar hexBinary content/attributes.
 	needsHex = schema.uniqueTypes()["hexBinary"] ~= nil
+	-- E3d namespace helpers (no-ops when the schema has no targetNamespace).
+	-- The single document-root element is always qualified in the target NS;
+	-- local elements/attributes are qualified only when their XSD form is.
+	docRootName = next(schema.types[schema.root].dependents)
+	local function nsIsQualified(name)
+		if not docRootNS then return false end
+		if name == docRootName then return true end
+		local info = nsByName[name]
+		return info ~= nil and info.qualified == true
+	end
+	-- Java expression for an element's namespace URI, or nil when unqualified.
+	function nsUriExpr(name)
+		return nsIsQualified(name) and ('"'..docRootNS..'"') or nil
+	end
 ]/* command to split output: csplit - '/\/\* FILE: /' {*} */
 [@lua if not needsHex then return "" end
 	return [[/* FILE: Hex.java */
@@ -67,6 +110,11 @@ public abstract class Element {
 	protected Factory _factory;
 
 	public abstract String localName();
+	/* Target-namespace URI for qualified elements; null = no namespace. */
+	protected String namespaceURI() { return null; }
+	/* Emit namespace declarations after this element's start tag (root only). */
+	protected void marshalNamespaces(XMLStreamWriter w)
+			throws XMLStreamException {}
 	protected void readAttributes(XMLStreamReader r) {}
 	protected void readContent() {}
 	protected void validate() {}
@@ -83,7 +131,13 @@ public abstract class Element {
 	}
 
 	public void marshal(XMLStreamWriter w) throws XMLStreamException {
-		w.writeStartElement(localName());
+		String ns = namespaceURI();
+		if (ns != null) {
+			w.writeStartElement(ns, localName());
+		} else {
+			w.writeStartElement(localName());
+		}
+		marshalNamespaces(w);
 		marshalAttributes(w);
 		marshalContent(w);
 		if (_children != null) {
@@ -181,7 +235,10 @@ public class Document {
 		XMLStreamWriter w =
 			XMLOutputFactory.newInstance().createXMLStreamWriter(sw);
 		w.writeStartDocument("UTF-8", "1.0");
-		root.marshal(w);
+[@lua return docRootNS
+		and ('\t\tw.setPrefix("'..nsPrefix..'", "'..docRootNS..'");\n')
+		or ""
+]		root.marshal(w);
 		w.writeEndDocument();
 		w.flush();
 		return sw.toString();
@@ -323,6 +380,24 @@ public class Document {
 			"\t@Override public String localName() { return \"",
 			node.name, "\"; }\n\n",
 		}))
+
+		-- E3d: qualified elements carry their namespace URI; the document root
+		-- additionally declares the bound prefix after its start tag.
+		local nsUri = nsUriExpr(node.name)
+		if nsUri then
+			outbuf:append(table.concat({
+				"\t@Override protected String namespaceURI() { return ",
+				nsUri, "; }\n\n",
+			}))
+		end
+		if docRootNS and node.name == docRootName then
+			outbuf:append(table.concat({
+				"\t@Override protected void marshalNamespaces(",
+				"XMLStreamWriter w) throws XMLStreamException {\n",
+				"\t\tw.writeNamespace(\"", nsPrefix, "\", \"", docRootNS,
+				"\");\n\t}\n\n",
+			}))
+		end
 
 		-- override only what differs from Element's empty defaults
 		if hasAttrs then

--- a/templates/python-sax
+++ b/templates/python-sax
@@ -1,4 +1,55 @@
-[@lua --include and transform old format
+[@lua -- E3c: snapshot element namespace/form BEFORE trnsfrm_old, which drops
+	-- the element-level namespace/qualified fields (it carries them only onto
+	-- leaf content/attributes). Build a stable name -> {ns, qualified} map and
+	-- record the document's target namespace from the single top-level element.
+	-- Gated entirely on a namespace being present: non-namespaced schemas leave
+	-- nsByName empty and emit byte-identical output.
+	nsByName = {}
+	nsTopLevel = {}
+	local function _nsCollect(name, node)
+		if type(node) ~= 'table' then return end
+		if node.namespace then
+			nsByName[name] = {ns = node.namespace, qualified = node.qualified}
+		end
+		table.map(node.content or {}, function(k, v) _nsCollect(k, v) end)
+	end
+	table.map(schema, function(k, v)
+		if type(v) == 'table' then
+			-- top-level elements are the document roots; only they declare xmlns
+			if v.namespace then nsTopLevel[k] = true end
+			_nsCollect(k, v)
+		end
+	end)
+	-- Deterministic synthesized prefix per URI (XSD source prefix is not in the
+	-- model); a single target NS gets "ns". Sort URIs for a stable nsN suffix.
+	local _uris = {}
+	table.map(nsByName, function(_, v) _uris[v.ns] = true end)
+	local _sorted = {}
+	table.map(_uris, function(uri, _) _sorted[#_sorted + 1] = uri end)
+	table.sort(_sorted)
+	nsPrefixOf = {}
+	for i, uri in ipairs(_sorted) do
+		nsPrefixOf[uri] = (#_sorted == 1) and 'ns' or ('ns' .. i)
+	end
+	-- Wire-tag for an element: prefixed when qualified, else bare local name.
+	function py_nsTag(localName)
+		local e = nsByName[localName]
+		if e and e.qualified then return nsPrefixOf[e.ns] .. ':' .. localName end
+		return localName
+	end
+	-- xmlns declaration(s) for the open tag (after "<tag"); "" except on a
+	-- top-level (document-root) element. Qualified roots bind a synthesized
+	-- prefix; unqualified roots bind the default xmlns so bare child tags
+	-- inherit the target NS.
+	function py_nsDecl(localName)
+		local e = nsByName[localName]
+		if not (e and nsTopLevel[localName]) then return '' end
+		if e.qualified then
+			return ' xmlns:' .. nsPrefixOf[e.ns] .. '="' .. e.ns .. '"'
+		end
+		return ' xmlns="' .. e.ns .. '"'
+	end
+][@lua --include and transform old format
 	include 'shared/trnsfrm_old'
 	schema = trnsfrm_oldFmt(schema)
 ][@lua --include any shared 'helper' templates
@@ -131,10 +182,12 @@ class _xmlelement:
 				end
 			end)
 		end
+		-- E3c: prefixed tag when qualified; xmlns decl on the document root.
 		outbuf:append(table.concat({
 			'\n',
 			'    def marshal(self, stream):\n',
-			'        stream.write(\'<', node.name, '\')\n',
+			'        stream.write(\'<', py_nsTag(node.name),
+				py_nsDecl(node.name), '\')\n',
 		}))
 		-- output marshal code for each element attribute
 		table.map(node.attributes, function(attributeName, attribute)
@@ -151,7 +204,7 @@ class _xmlelement:
 			}))
 		end
 		outbuf:append(table.concat({
-			'        stream.write(\'</', node.name, '>\')\n',
+			'        stream.write(\'</', py_nsTag(node.name), '>\')\n',
 			'\n',
 			'    def unmarshal(self, attributes, content):\n',
 		}))

--- a/templates/python-sax-test
+++ b/templates/python-sax-test
@@ -1,4 +1,46 @@
-[@lua --include and transform old format
+[@lua -- E3c: snapshot element namespace/form BEFORE trnsfrm_old drops the
+	-- element-level fields. The generated test XML must match what the binding
+	-- marshals, so the same prefix/xmlns rules are applied here. Gated on a
+	-- namespace being present: non-namespaced schemas emit byte-identical XML.
+	nsByName = {}
+	nsTopLevel = {}
+	local function _nsCollect(name, node)
+		if type(node) ~= 'table' then return end
+		if node.namespace then
+			nsByName[name] = {ns = node.namespace, qualified = node.qualified}
+		end
+		table.map(node.content or {}, function(k, v) _nsCollect(k, v) end)
+	end
+	table.map(schema, function(k, v)
+		if type(v) == 'table' then
+			if v.namespace then nsTopLevel[k] = true end
+			_nsCollect(k, v)
+		end
+	end)
+	local _uris = {}
+	table.map(nsByName, function(_, v) _uris[v.ns] = true end)
+	local _sorted = {}
+	table.map(_uris, function(uri, _) _sorted[#_sorted + 1] = uri end)
+	table.sort(_sorted)
+	nsPrefixOf = {}
+	for i, uri in ipairs(_sorted) do
+		nsPrefixOf[uri] = (#_sorted == 1) and 'ns' or ('ns' .. i)
+	end
+	function py_nsTag(localName)
+		local e = nsByName[localName]
+		if e and e.qualified then return nsPrefixOf[e.ns] .. ':' .. localName end
+		return localName
+	end
+	-- Plain-text xmlns decl (the test XML is a Python literal, not escaped).
+	function py_nsDecl(localName)
+		local e = nsByName[localName]
+		if not (e and nsTopLevel[localName]) then return '' end
+		if e.qualified then
+			return ' xmlns:' .. nsPrefixOf[e.ns] .. '=\\"' .. e.ns .. '\\"'
+		end
+		return ' xmlns=\\"' .. e.ns .. '\\"'
+	end
+][@lua --include and transform old format
 	include 'shared/trnsfrm_old'
 	schema = trnsfrm_oldFmt(schema)
 ][@lua --include any shared 'helper' templates
@@ -17,7 +59,9 @@ test = [
 [@lua --output each test xml file
 	local outbuf = stringBuffer:new()
 	local function dpOutput(_, node)
-		outbuf:append(table.concat({'<', node.name}))
+		-- E3c: match the binding's wire form (prefix when qualified, xmlns on
+		-- the document root).
+		outbuf:append(table.concat({'<', py_nsTag(node.name), py_nsDecl(node.name)}))
 		table.map(node.attributes, function(attribName, attrib)
 			outbuf:append(table.concat({
 				' ', attribName, '=\\"', py_type_info[attrib.type].test.assign(attrib.facets), '\\"',
@@ -30,7 +74,7 @@ test = [
 		if next(node.dependents) then
 			table.map(node.dependents, dpOutput)
 		end
-		outbuf:append(table.concat({'</', node.name, '>'}))
+		outbuf:append(table.concat({'</', py_nsTag(node.name), '>'}))
 	end
 	table.map(schema.types[schema.root].dependents, function(name, node)
 		outbuf:append('    "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>\\n" \\\n    "')

--- a/templates/shared/trnsfrm_old
+++ b/templates/shared/trnsfrm_old
@@ -60,7 +60,13 @@ function trnsfrm_oldFmt(tbl)
 				if isBaseType(v) and substate == Substate.ContentNotFound then
 					-- carry the leaf type's facets (D1) onto the normalized
 					-- content so targets can emit validation/narrowing.
-					outTbl['content'] = { type = k, facets = v.facets }
+					-- namespace/qualified (E) ride along, nil when absent.
+					outTbl['content'] = {
+						type = k,
+						facets = v.facets,
+						namespace = v.namespace,
+						qualified = v.qualified
+					}
 					substate = Substate.ContentFound
 				elseif not isBaseType(v) then
 					outTbl.dependents[k]={}
@@ -81,6 +87,9 @@ function trnsfrm_oldFmt(tbl)
 				outTbl.type = attribName
 				-- carry the attribute's restriction facets up for validation
 				outTbl.facets = attribDef.facets
+				-- namespace/qualified (E) ride along, nil when absent
+				outTbl.namespace = attribDef.namespace
+				outTbl.qualified = attribDef.qualified
 				if nil ~= attribDef.default then
 					outTbl.default = attribDef.default
 				end

--- a/test/facetTests.cpp
+++ b/test/facetTests.cpp
@@ -108,3 +108,17 @@ TEST(Bug, AnnotationInStringRestriction) {
 	EXPECT_NO_THROW(
 		gen("python-sax", CORPUS + "bug_restriction_annotation.xsd"));
 }
+
+/* E3: every XML target references the targetNamespace URI for a namespaced
+ * schema (emitted as xmlns/xmlns:tns at marshal time — literal in the C/python
+ * output, via the StAX namespace API in Java). Non-namespaced output stays
+ * bare. */
+TEST(Namespace, EmittedAcrossXmlTargets) {
+	const std::string xsd = CORPUS + "nsTargetPrefixed.xsd";
+	const char* tmpls[] = { "c-xml-expat", "c-xml-expat-dom.template",
+	                        "python-sax", "java-xml-stax.tmpl" };
+	for (size_t i = 0; i < sizeof(tmpls) / sizeof(*tmpls); ++i)
+		EXPECT_TRUE(has(gen(tmpls[i], xsd), "urn:example:phase0")) << tmpls[i];
+	/* a non-namespaced schema emits no xmlns */
+	EXPECT_FALSE(has(gen("c-xml-expat", CORPUS + "testA001.xsd"), "xmlns="));
+}

--- a/test/parserTests.cpp
+++ b/test/parserTests.cpp
@@ -98,3 +98,17 @@ TEST(Schema, DefaultNamespaceEqualsTargetResolves) {
 	EXPECT_EQ(std::string(XSD::XSD_NS), root->ResolvePrefix("xs"));
 	delete root;
 }
+
+/* E2: the importing schema declares the imported namespace on a prefix; the
+ * prefix resolves to the imported namespace URI (end-to-end cross-document
+ * type resolution is covered by the nsImport golden in generateTests). */
+TEST(Schema, ImportedNamespacePrefixResolves) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(root = parser.Parse(
+		std::string(XSD_CORPUS_DIR "/nsImport.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string("urn:example:order"), root->TargetNamespace());
+	EXPECT_EQ(std::string("urn:example:address"), root->ResolvePrefix("addr"));
+	delete root;
+}

--- a/test/parserTests.cpp
+++ b/test/parserTests.cpp
@@ -8,6 +8,7 @@
 #include "src/XSDParser/Parser.hpp"
 #include "src/XSDParser/Elements/Schema.hpp"
 #include "src/XSDParser/Exception.hpp"
+#include "src/XSDParser/XsdQName.hpp"
 
 TEST(Parser, ParsesPositiveSchema) {
 	XSD::Parser parser;
@@ -22,4 +23,78 @@ TEST(Parser, ThrowsOnMissingFile) {
 	XSD::Parser parser;
 	EXPECT_THROW(parser.Parse(std::string("/nonexistent/missing.xsd")),
 	             XSD::XMLException);
+}
+
+/* Phase 0 regression: a schema declaring no namespace at all must still
+ * resolve bare builtin refs (testA010 uses base="string" with no xmlns).
+ * ns-by-URI builtin detection would otherwise reject it. */
+TEST(Schema, NoNamespaceResolvesBareBuiltins) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(
+		root = parser.Parse(std::string(XSD_CORPUS_DIR "/testA010.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string(""), root->Namespace());
+	EXPECT_EQ(std::string(""), root->TargetNamespace());
+	EXPECT_EQ(std::string(""), root->ResolvePrefix(""));
+	delete root;
+}
+
+/* The XSD-lang declared as the bare default xmlns: the default prefix
+ * resolves to XSD_NS, and Namespace() preserves its legacy "xmlns" tag
+ * sentinel (QualifyElementName specifically skips "xmlns", so no prefix is
+ * prepended). */
+TEST(Schema, DefaultNamespaceIsXsdLang) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(
+		root = parser.Parse(std::string(XSD_CORPUS_DIR "/testA034.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string("xmlns"), root->Namespace());
+	EXPECT_EQ(std::string(XSD::XSD_NS), root->ResolvePrefix(""));
+	delete root;
+}
+
+/* Prefixed XSD-lang form: Namespace() returns the "xs" tag prefix and the
+ * prefix resolves to XSD_NS; an undeclared prefix resolves to "". */
+TEST(Schema, PrefixedXsdLangResolves) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(
+		root = parser.Parse(std::string(XSD_CORPUS_DIR "/bug_union.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string("xs"), root->Namespace());
+	EXPECT_EQ(std::string(XSD::XSD_NS), root->ResolvePrefix("xs"));
+	EXPECT_EQ(std::string(""), root->ResolvePrefix("undeclared"));
+	delete root;
+}
+
+/* Multi-namespace positive case: XSD-lang on "xs", the target on "tns".
+ * A prefixed self-ref type="tns:RecordType" resolves to the same-document
+ * target NS; the whole schema generates without throwing. */
+TEST(Schema, TargetNamespacePrefixedSelfRefResolves) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(root = parser.Parse(
+		std::string(XSD_CORPUS_DIR "/nsTargetPrefixed.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string("urn:example:phase0"), root->TargetNamespace());
+	EXPECT_EQ(std::string("urn:example:phase0"), root->ResolvePrefix("tns"));
+	EXPECT_EQ(std::string(XSD::XSD_NS), root->ResolvePrefix("xs"));
+	delete root;
+}
+
+/* Multi-namespace positive case: the default xmlns equals the target, so an
+ * unprefixed self-ref resolves through the default-xmlns URI to the target. */
+TEST(Schema, DefaultNamespaceEqualsTargetResolves) {
+	XSD::Parser parser;
+	XSD::Elements::Schema* root = NULL;
+	ASSERT_NO_THROW(root = parser.Parse(
+		std::string(XSD_CORPUS_DIR "/nsTargetDefault.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, root);
+	EXPECT_EQ(std::string("urn:example:phase0default"),
+	          root->TargetNamespace());
+	EXPECT_EQ(std::string("urn:example:phase0default"), root->ResolvePrefix(""));
+	EXPECT_EQ(std::string(XSD::XSD_NS), root->ResolvePrefix("xs"));
+	delete root;
 }

--- a/test/xsd-negative/nsImportMissing.xsd
+++ b/test/xsd-negative/nsImportMissing.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- E2 negative: references a cross-namespace type (addr:AddressType) with no
+     xs:import declaring that namespace, so resolution must throw. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:order"
+           xmlns:addr="urn:example:address"
+           targetNamespace="urn:example:order">
+  <xs:element name="order">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="shipTo" type="addr:AddressType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/include/AddressType.xsd
+++ b/test/xsd-positive/include/AddressType.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Imported secondary schema (namespace B). Defines AddressType, referenced
+     cross-namespace from nsImport.xsd via xs:import. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:example:address">
+  <xs:complexType name="AddressType">
+    <xs:sequence>
+      <xs:element name="street" type="xs:string"/>
+      <xs:element name="zip" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/test/xsd-positive/nsImport.xsd
+++ b/test/xsd-positive/nsImport.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- E2: primary schema (target NS A) xs:imports a different-namespace schema
+     (NS B on the "addr" prefix) and references AddressType cross-namespace via
+     a prefixed type="addr:AddressType". -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:order"
+           xmlns:addr="urn:example:address"
+           targetNamespace="urn:example:order">
+  <xs:import namespace="urn:example:address"
+             schemaLocation="include/AddressType.xsd"/>
+  <xs:element name="order">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="id" type="xs:string"/>
+        <xs:element name="shipTo" type="addr:AddressType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/nsTargetDefault.xsd
+++ b/test/xsd-positive/nsTargetDefault.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Phase 0 (E1): default-namespace-as-target. The default xmlns equals the
+     targetNamespace, so an UNPREFIXED self-reference type="RecordType"
+     resolves to the target NS (ResolveQName_ maps no-prefix via the default
+     xmlns URI, never assuming XSD_NS). Builtins are reached via the xs:
+     prefix. -->
+<xs:schema xmlns="urn:example:phase0default"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:example:phase0default">
+  <xs:element name="record" type="RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/test/xsd-positive/nsTargetPrefixed.xsd
+++ b/test/xsd-positive/nsTargetPrefixed.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Phase 0 (E1): single targetNamespace with the XSD-lang on the "xs"
+     prefix and the target on "tns". A prefixed self-reference
+     type="tns:RecordType" must resolve to the same-document target NS, while
+     xs:string is detected as a builtin by its namespace URI. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:phase0"
+           targetNamespace="urn:example:phase0">
+  <xs:element name="record" type="tns:RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="count" type="xs:integer"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>

--- a/test/xsdparse/nsImport.out
+++ b/test/xsdparse/nsImport.out
@@ -1,0 +1,58 @@
+order = {
+	attributes = {}
+	namespace = urn:example:order
+	maxOccurs = 1
+	content = {
+		id = {
+			attributes = {}
+			namespace = urn:example:order
+			maxOccurs = 1
+			content = {
+				string = {
+					attributes = {}
+					maxOccurs = 1
+					content = {}
+					minOccurs = 1
+				}
+			}
+			minOccurs = 1
+		}
+		shipTo = {
+			attributes = {}
+			namespace = urn:example:order
+			maxOccurs = 1
+			content = {
+				zip = {
+					attributes = {}
+					namespace = urn:example:address
+					maxOccurs = 1
+					content = {
+						string = {
+							attributes = {}
+							maxOccurs = 1
+							content = {}
+							minOccurs = 1
+						}
+					}
+					minOccurs = 1
+				}
+				street = {
+					attributes = {}
+					namespace = urn:example:address
+					maxOccurs = 1
+					content = {
+						string = {
+							attributes = {}
+							maxOccurs = 1
+							content = {}
+							minOccurs = 1
+						}
+					}
+					minOccurs = 1
+				}
+			}
+			minOccurs = 1
+		}
+	}
+	minOccurs = 1
+}

--- a/test/xsdparse/nsTargetDefault.out
+++ b/test/xsdparse/nsTargetDefault.out
@@ -1,0 +1,20 @@
+record = {
+	attributes = {}
+	maxOccurs = 1
+	content = {
+		label = {
+			attributes = {}
+			maxOccurs = 1
+			content = {
+				string = {
+					attributes = {}
+					maxOccurs = 1
+					content = {}
+					minOccurs = 1
+				}
+			}
+			minOccurs = 1
+		}
+	}
+	minOccurs = 1
+}

--- a/test/xsdparse/nsTargetDefault.out
+++ b/test/xsdparse/nsTargetDefault.out
@@ -1,9 +1,11 @@
 record = {
 	attributes = {}
+	namespace = urn:example:phase0default
 	maxOccurs = 1
 	content = {
 		label = {
 			attributes = {}
+			namespace = urn:example:phase0default
 			maxOccurs = 1
 			content = {
 				string = {

--- a/test/xsdparse/nsTargetPrefixed.out
+++ b/test/xsdparse/nsTargetPrefixed.out
@@ -1,0 +1,43 @@
+record = {
+	attributes = {
+		id = {
+			string = {
+				attributes = {}
+				use = optional
+				maxOccurs = 1
+				content = {}
+				minOccurs = 1
+			}
+		}
+	}
+	maxOccurs = 1
+	content = {
+		count = {
+			attributes = {}
+			maxOccurs = 1
+			content = {
+				integer = {
+					attributes = {}
+					maxOccurs = 1
+					content = {}
+					minOccurs = 1
+				}
+			}
+			minOccurs = 1
+		}
+		label = {
+			attributes = {}
+			maxOccurs = 1
+			content = {
+				string = {
+					attributes = {}
+					maxOccurs = 1
+					content = {}
+					minOccurs = 1
+				}
+			}
+			minOccurs = 1
+		}
+	}
+	minOccurs = 1
+}

--- a/test/xsdparse/nsTargetPrefixed.out
+++ b/test/xsdparse/nsTargetPrefixed.out
@@ -3,6 +3,7 @@ record = {
 		id = {
 			string = {
 				attributes = {}
+				namespace = urn:example:phase0
 				use = optional
 				maxOccurs = 1
 				content = {}
@@ -10,10 +11,12 @@ record = {
 			}
 		}
 	}
+	namespace = urn:example:phase0
 	maxOccurs = 1
 	content = {
 		count = {
 			attributes = {}
+			namespace = urn:example:phase0
 			maxOccurs = 1
 			content = {
 				integer = {
@@ -27,6 +30,7 @@ record = {
 		}
 		label = {
 			attributes = {}
+			namespace = urn:example:phase0
 			maxOccurs = 1
 			content = {
 				string = {


### PR DESCRIPTION
Workstream E — namespace awareness + `xs:import`. Built as a frozen-contract foundation then parallel lanes; full suite **426 / 0**, the 42 pre-existing model goldens byte-identical throughout.

**Phase 0 — QName resolution contract** (behavior-preserving): new `XsdQName{ns,local}` + `XSD_NS`; `Schema::TargetNamespace()`/`ResolvePrefix()` with a byte-identical `Namespace()`; `Node::ResolveQName_` detects builtins by namespace **URI** (not the `xs` prefix); `XsdQName` threaded through the `Type_`/`FindXSDElm_`/`FindXSDNode_`/`FindXSDRef_` chain; same-`targetNamespace` finder predicate. `QualifyElementName` untouched.

**Bridge** — optional `namespace`/`qualified` Lua-model fields on each element/attribute, empty-gated like `Facets` (only the 2 namespace fixtures' goldens changed).

**E3 — namespace emission across all four XML targets** (`c-xml-expat`, `c-xml-expat-dom`, `python-sax`, `java-xml-stax`): emit `xmlns`/prefix on the root, qualify names per `qualified`, match by URI + local name on parse; non-namespaced schemas byte-identical.

**E2 — `xs:import`**: new `Import` element + non-pure `ProcessImport`, a `Parser` namespace index, and cross-namespace resolution hooked at `FindXSDElm_`'s fallthrough (contrast `xs:include`'s same-namespace merge). Two-file import fixture + a negative unresolved-import case.

**Also:** cyclic schemas already raise `CyclicTypeDefinition` (J, prior PR); Windows CI incbin fix (`-Ipath` glue) rides along. README drops "not namespace aware"; CHANGELOG closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784976709&installation_id=141995922&pr_number=39&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F39&signature=38b407cf69f4b79363f63c0d7044ecf7d3872f4702f7d4d7e3e55b3f4dce0602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->