### PR TITLE
ci/ts-xml: fix tsconfig outDir + node on CI runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,12 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      # Node for the ts-xml round-trips (tsc + fast-xml-parser via npm).
+      # lts/* tracks the current LTS so the version never ages into EOL.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
       # Warm the shared Maven local repo across runs: the Java round-trips
       # all read ~/.m2, so a cold runner would otherwise re-download every
       # dependency. Locally this cache is already warm; it only matters here.
@@ -106,6 +112,12 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+
+      # Node for the ts-xml round-trips (tsc + fast-xml-parser via npm).
+      # lts/* tracks the current LTS so the version never ages into EOL.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
 
       - uses: actions/cache@v4
         with:

--- a/test/ts-xml/tsconfig.json
+++ b/test/ts-xml/tsconfig.json
@@ -6,7 +6,6 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "outDir": "."
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
The `revitalize → master` CI fails on all `TsXmlRoundtrip` cases with `error TS18003: No inputs were found`. Root cause: the ts-xml `tsconfig.json` sets `outDir: "."`, and tsc auto-excludes its `outDir` from inputs — so with outDir = the whole dir, tsc has nothing to compile.

- **Fix:** drop `outDir` (tsc emits `.js` alongside the sources; the helper runs `node RunTest.js` from the project root).
- **CI:** add `actions/setup-node` (`lts/*`) to the unix + windows jobs so the ts-xml suite runs on a current LTS — node 20 is near EOL, and `lts/*` never ages out.

Note: ts-xml had no end-to-end run before this (no node in the dev env), so this PR's CI is its first real `tsc`/`node` validation. The cpp targets are unaffected (validated 110/110). If CI surfaces further ts-xml issues now that tsc actually runs, I'll fix them in follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784998137&installation_id=141995922&pr_number=41&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F41&signature=7b9c8857082b23e543ec0dd870170606cce4b27af2fdb23ee3e09f16aec4bc20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->