### PR TITLE
cpp-json-jsonc: unify factory onto virtual Factory (match cpp-xml-expat)

### DIFF
--- a/templates/cpp-json-jsonc.template
+++ b/templates/cpp-json-jsonc.template
@@ -132,28 +132,22 @@ struct json_marshaller {
 	return outbuf:str()
 ]};
 
-/* Overridable per-type factory: every element on the unmarshal path is
- * allocated/constructed/destroyed through this triple, so a caller can inject a
- * subtype by supplying their own std::functions. A default-constructed table
- * (or any empty member) falls back to new / no-op construct / delete. */
-struct json_[@lua return schemaName]_factories {
-[@lua --output per-type Allocator/Constructor/Destructor std::functions
+/* Overridable factory: a consumer subclasses this and overrides create() to
+ * inject element subtypes. Default returns the generated class. Mirrors
+ * cpp-xml-expat's Factory; one virtual covers allocate+construct and the
+ * returned unique_ptr covers destroy. */
+class Factory {
+public:
+	virtual ~Factory() {}
+[@lua --output one create_<name>() virtual per complex type
 	local outbuf = stringBuffer:new()
 	table.map(depOrderSansRoot, function(_, node)
-		outbuf:append(string.format(
-			'\tstd::function<json_%s*(json_marshaller& marshaller)> %sAllocator;\n',
-			node.name, node.name))
-		outbuf:append(string.format(
-			'\tstd::function<void(json_marshaller& marshaller, json_%s* pObj)> %sConstructor;\n',
-			node.name, node.name))
-		outbuf:append(string.format(
-			'\tstd::function<void(json_marshaller& marshaller, json_%s* pObj)> %sDestructor;\n',
-			node.name, node.name))
+		outbuf:append('\tvirtual std::unique_ptr<json_'..node.name
+			..'> create_'..node.name..'() const {\n\t\treturn std::unique_ptr<json_'
+			..node.name..'>(new json_'..node.name..'());\n\t}\n')
 	end)
 	return outbuf:str()
 ]};
-
-const json_[@lua return schemaName]_factories& json_[@lua return schemaName]_default_factories();
 
 [@lua --output marshalling callback structs
 	local outbuf = stringBuffer:new()
@@ -187,7 +181,7 @@ const json_[@lua return schemaName]_factories& json_[@lua return schemaName]_def
 	end
 ]json_buffer json_marshal_flush(json_marshaller& marshaller, bool isDocEnd);
 void json_unmarshal(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd);
-void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd, const json_[@lua return schemaName]_factories& factories);
+void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd, const Factory& factory);
 
 #endif
 
@@ -208,25 +202,6 @@ void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool
 	end
 ]
 namespace {
-
-/* Per-type factory dispatch, empty-safe with default fallback. The Allocator
- * yields a raw owning pointer; the caller binds it to a unique_ptr whose
- * deleter routes back through DestroyElement so each object is freed once. */
-template <typename T>
-T* AllocateElement(const std::function<T*(json_marshaller&)>& alloc,
-                   json_marshaller& m) {
-	return alloc ? alloc(m) : new T();
-}
-template <typename T>
-void ConstructElement(const std::function<void(json_marshaller&, T*)>& ctor,
-                      json_marshaller& m, T* pObj) {
-	if (ctor) ctor(m, pObj);
-}
-template <typename T>
-void DestroyElement(const std::function<void(json_marshaller&, T*)>& dtor,
-                    json_marshaller& m, T* pObj) {
-	if (dtor) dtor(m, pObj); else delete pObj;
-}
 
 [@lua -- gtlssIdCnt seeds eid_, used only when some node has dependents
 	local hasParent = table.filter(depOrderSansRoot, function(_, node)
@@ -356,26 +331,12 @@ namespace {
 ]
 } /* namespace */
 
-[@lua -- output default factory triple + table
-	local outbuf = stringBuffer:new()
-	-- default allocator: new'd object; seed eid_ when the node has dependents.
-	-- default destructor: plain delete. Constructor left empty (no-op).
-	outbuf:append('const json_'..schemaName..'_factories& json_'..schemaName..'_default_factories() {\n')
-	outbuf:append('\tstatic const json_'..schemaName..'_factories g_defaultFactories = []() {\n')
-	outbuf:append('\t\tjson_'..schemaName..'_factories f;\n')
-	table.map(depOrderSansRoot, function(_, node)
-		outbuf:append('\t\tf.'..node.name..'Allocator = [](json_marshaller&) -> json_'..node.name..'* {\n')
-		outbuf:append('\t\t\tjson_'..node.name..'* pObj = new json_'..node.name..'();\n')
-		if next(node.dependents) then
-			outbuf:append('\t\t\tpObj->eid_ = gtlssIdCnt++;\n')
-		end
-		outbuf:append('\t\t\treturn pObj;\n\t\t};\n')
-		outbuf:append('\t\tf.'..node.name..'Destructor = [](json_marshaller&, json_'..node.name..'* pObj) { delete pObj; };\n')
-	end)
-	outbuf:append('\t\treturn f;\n\t}();\n')
-	outbuf:append('\treturn g_defaultFactories;\n}\n')
-	return outbuf:str()
-]
+/* Default factory used when json_unmarshal() is called without an override. */
+static const Factory& defaultFactory_() {
+	static const Factory f;
+	return f;
+}
+
 [@lua -- output facet-validation members (D2): per element with restricted
 	-- content/attributes, json_<name>::validate() throws std::runtime_error on a
 	-- violation and returns true otherwise. Pattern facets (P3) are not enforced.
@@ -468,23 +429,25 @@ namespace {
 [@lua -- forward-declare per-element unmarshalElm helpers
 	local outbuf = stringBuffer:new()
 	table.map(depOrderSansRoot, function(_, node)
-		outbuf:append('void unmarshalElm_'..node.name..'_(json_marshaller& marshaller, json_object* pJson, const json_'..schemaName..'_factories& factories, uint32_t parentId);\n')
+		outbuf:append('void unmarshalElm_'..node.name..'_(json_marshaller& marshaller, json_object* pJson, const Factory& factory, uint32_t parentId);\n')
 	end)
 	return outbuf:str()
 ]
 [@lua -- per-element unmarshalElm helpers (RAII over the allocated object)
 	local outbuf = stringBuffer:new()
 	table.map(depOrderSansRoot, function(_, node)
-		outbuf:append('void unmarshalElm_'..node.name..'_(json_marshaller& marshaller, json_object* pJson, const json_'..schemaName..'_factories& factories, uint32_t parentId) {\n')
+		outbuf:append('void unmarshalElm_'..node.name..'_(json_marshaller& marshaller, json_object* pJson, const Factory& factory, uint32_t parentId) {\n')
 		outbuf:append('\tjson_object* pField = nullptr;\n')
 		outbuf:append('\t(void)pField;\n')
-		-- allocate via the factory; own through a unique_ptr that routes its
-		-- deleter back through DestroyElement so each object is freed once.
-		outbuf:append('\tjson_'..node.name..'* pRaw = AllocateElement<json_'..node.name..'>(factories.'..node.name..'Allocator, marshaller);\n')
-		outbuf:append('\tConstructElement<json_'..node.name..'>(factories.'..node.name..'Constructor, marshaller, pRaw);\n')
-		outbuf:append('\tstd::unique_ptr<json_'..node.name..', std::function<void(json_'..node.name..'*)> > pObjOwner(\n')
-		outbuf:append('\t\tpRaw, [&](json_'..node.name..'* p) { DestroyElement<json_'..node.name..'>(factories.'..node.name..'Destructor, marshaller, p); });\n')
+		-- allocate via the factory; the returned unique_ptr owns the object and
+		-- frees it on scope exit.
+		outbuf:append('\tstd::unique_ptr<json_'..node.name..'> pObjOwner = factory.create_'..node.name..'();\n')
 		outbuf:append('\tjson_'..node.name..'* pObj = pObjOwner.get();\n')
+		-- eid_ seeds children's parentId; assigned here since the factory body
+		-- is consumer-overridable.
+		if next(node.dependents) then
+			outbuf:append('\tpObj->eid_ = gtlssIdCnt++;\n')
+		end
 		local objName = 'pObj->'
 		-- defaults
 		table.map(node.attributes, function(name, attrib)
@@ -511,7 +474,7 @@ namespace {
 		-- recurse into child elements
 		table.map(node.dependents, function(_, child)
 			outbuf:append('\tif (json_object_object_get_ex(pJson, "'..child.name..'", &pField)) {\n')
-			outbuf:append('\t\tunmarshalElm_'..child.name..'_(marshaller, pField, factories, pObj->eid_);\n')
+			outbuf:append('\t\tunmarshalElm_'..child.name..'_(marshaller, pField, factory, pObj->eid_);\n')
 			outbuf:append('\t}\n')
 		end)
 		-- validate (D2) gates only the notify; the object is freed by pObjOwner
@@ -525,7 +488,7 @@ namespace {
 ]
 } /* namespace */
 
-void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd, const json_[@lua return schemaName]_factories& factories) {
+void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd, const Factory& factory) {
 	(void)isDocEnd;
 	JsonRef root(json_tokener_parse(buf.c_str()));
 	json_object* pField = nullptr;
@@ -535,7 +498,7 @@ void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool
 	local outbuf = stringBuffer:new()
 	table.map(schema.types[schema.root].dependents, function(_, child)
 		outbuf:append('\t\tif (json_object_object_get_ex(root.get(), "'..child.name..'", &pField)) {\n')
-		outbuf:append('\t\t\tunmarshalElm_'..child.name..'_(marshaller, pField, factories, 0);\n')
+		outbuf:append('\t\t\tunmarshalElm_'..child.name..'_(marshaller, pField, factory, 0);\n')
 		outbuf:append('\t\t}\n')
 	end)
 	return outbuf:str()
@@ -543,5 +506,5 @@ void json_unmarshal_ex(json_marshaller& marshaller, const json_buffer& buf, bool
 }
 
 void json_unmarshal(json_marshaller& marshaller, const json_buffer& buf, bool isDocEnd) {
-	json_unmarshal_ex(marshaller, buf, isDocEnd, json_[@lua return schemaName]_default_factories());
+	json_unmarshal_ex(marshaller, buf, isDocEnd, defaultFactory_());
 }

--- a/templates/cpp-json-jsonc.template-test
+++ b/templates/cpp-json-jsonc.template-test
@@ -83,28 +83,27 @@
 	return outbuf:str()
 ]
 
-/* Exercise the overridable factory triple: wrappers delegate to the defaults
- * but count alloc/construct/destroy so we can assert the path is taken and
- * balanced. */
-static int g_allocCnt = 0;
-static int g_constructCnt = 0;
+/* Exercise the overridable Factory: a subclass counts create()s and returns an
+ * instrumented subtype whose dtor counts destructions, so we can assert the
+ * inject path is taken and that every created object is freed. */
+static int g_createCnt = 0;
 static int g_destroyCnt = 0;
 
-[@lua -- build the override factories table
+[@lua -- build the override Factory subclass
 	local outbuf = stringBuffer:new()
-	local dft = 'json_'..schemaName..'_default_factories()'
-	outbuf:append('static json_'..schemaName..'_factories makeOverrideFactories() {\n')
-	outbuf:append('\tjson_'..schemaName..'_factories f;\n')
+	-- one instrumented subtype per complex type that counts its own destruction
 	table.map(typeSansRoot, function(_, node)
-		outbuf:append('\tf.'..node.name..'Allocator = [](json_marshaller& m) -> json_'..node.name..'* {\n')
-		outbuf:append('\t\t++g_allocCnt;\n')
-		outbuf:append('\t\treturn '..dft..'.'..node.name..'Allocator(m);\n\t};\n')
-		outbuf:append('\tf.'..node.name..'Constructor = [](json_marshaller&, json_'..node.name..'*) { ++g_constructCnt; };\n')
-		outbuf:append('\tf.'..node.name..'Destructor = [](json_marshaller& m, json_'..node.name..'* pObj) {\n')
-		outbuf:append('\t\t++g_destroyCnt;\n')
-		outbuf:append('\t\t'..dft..'.'..node.name..'Destructor(m, pObj);\n\t};\n')
+		outbuf:append('struct Counting_'..node.name..' : json_'..node.name..' {\n')
+		outbuf:append('\t~Counting_'..node.name..'() override { ++g_destroyCnt; }\n')
+		outbuf:append('};\n')
 	end)
-	outbuf:append('\treturn f;\n}\n')
+	outbuf:append('class CountingFactory : public Factory {\npublic:\n')
+	table.map(typeSansRoot, function(_, node)
+		outbuf:append('\tstd::unique_ptr<json_'..node.name..'> create_'..node.name..'() const override {\n')
+		outbuf:append('\t\t++g_createCnt;\n')
+		outbuf:append('\t\treturn std::unique_ptr<json_'..node.name..'>(new Counting_'..node.name..'());\n\t}\n')
+	end)
+	outbuf:append('};\n')
 	return outbuf:str()
 ]
 
@@ -152,17 +151,16 @@ int main() {
 	return outbuf:str()
 ]	json_buffer output = json_marshal_flush(mrshllr, true);
 
-	/* test unmarshalling through the default factory table */
-	json_unmarshal_ex(mrshllr, output, true, json_[@lua return schemaName]_default_factories());
-	/* re-run through the override table to exercise the factory triple */
-	static const json_[@lua return schemaName]_factories overrides = makeOverrideFactories();
+	/* test unmarshalling through the default factory */
+	json_unmarshal(mrshllr, output, true);
+	/* re-run through the override Factory to exercise the inject path */
+	CountingFactory overrides;
 	json_unmarshal_ex(mrshllr, output, true, overrides);
 [@lua -- assert the override path ran (skip when schema has no elements)
 	if next(typeSansRoot) then
 		return table.concat({
-			'\tassert(g_allocCnt > 0);\n',
-			'\tassert(g_allocCnt == g_constructCnt);\n',
-			'\tassert(g_allocCnt == g_destroyCnt);\n',
+			'\tassert(g_createCnt > 0);\n',
+			'\tassert(g_createCnt == g_destroyCnt);\n',
 		})
 	end
 	return ''


### PR DESCRIPTION
Both C++ targets now construct types through the same overridable virtual `Factory` API. cpp-json-jsonc drops the `std::function` Allocator/Constructor/Destructor table in favour of `virtual std::unique_ptr<json_<name>> create_<name>() const` (subclass + override to inject subtypes), exactly like cpp-xml-expat. `unique_ptr` handles destruction; `json_unmarshal` uses a default `Factory`, `json_unmarshal_ex` takes a `const Factory&`. The -test driver proves injection via a `CountingFactory` subclass. CppJsonRoundtrip 55/55, model goldens byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785000140&installation_id=141995922&pr_number=43&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F43&signature=6dd6471fe3c324a94da005aaa22a13d5bbdf784f817f2045a52049ddd80bdcd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->