### PR TITLE
ts-xml: fix Factory.create for abstract-only schemas (TS never)

### DIFF
--- a/templates/ts-xml.tmpl
+++ b/templates/ts-xml.tmpl
@@ -177,19 +177,26 @@ export class Factory {
 ]
 	/* Dispatch a local name to a freshly created element, or undefined. */
 	create(localName: string): Element | undefined {
-		let e: Element | undefined;
 [@lua
+	-- No concrete types (e.g. an abstract-only schema): a bare
+	-- `e = undefined` makes tsc narrow `e` to `never` at `if (e)`. Emit a
+	-- trivial body instead.
+	if next(depOrderSansRoot) == nil then
+		return "\t\treturn undefined;\n"
+	end
 	local outbuf = stringBuffer:new()
+	outbuf:append("\t\tlet e: Element | undefined;\n")
 	table.map(depOrderSansRoot, function(_, node)
 		outbuf:append(table.concat({
 			"\t\tif (localName === \"", node.name, "\") e = this.create",
 			tsSafeName(node.name), "();\n\t\telse ",
 		}))
 	end)
+	outbuf:append("e = undefined;\n")
+	outbuf:append("\t\tif (e) e.factory = this;\n")
+	outbuf:append("\t\treturn e;\n")
 	return outbuf:str()
-]e = undefined;
-		if (e) e.factory = this;
-		return e;
+]
 	}
 }
 


### PR DESCRIPTION
Last ts-xml CI failure. `elemB001` (`<element name="foo" abstract="true"/>`) has no concrete types, so `create()`'s only statement was `e = undefined;` — tsc narrows `e` to `never` at `if (e) e.factory = this` (TS2339). When there are no creatable types, emit `return undefined;`; the dispatch chain is unchanged otherwise. Verified by generation (abstract-only → trivial body; typed → full chain). With #42's bigint fix already merged, this should bring ts-xml fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785000420&installation_id=141995922&pr_number=44&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F44&signature=f38a9b62deff2bf84d886b198d9b40f5be548de5ede34642464ca68b6c494fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->