### PR TITLE
ci: fix Windows incbin build + move actions off node20

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,22 +29,22 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       # Node for the ts-xml round-trips (tsc + fast-xml-parser via npm).
       # lts/* tracks the current LTS so the version never ages into EOL.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
 
@@ -100,22 +100,22 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       # Node for the ts-xml round-trips (tsc + fast-xml-parser via npm).
       # lts/* tracks the current LTS so the version never ages into EOL.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,11 +370,11 @@ if(MSVC)
   set(_incbin_data "${CMAKE_BINARY_DIR}/generated/luascript_data.c")
   add_custom_command(
     OUTPUT "${_incbin_data}"
-    # incbin's arg parser only accepts the glued -Ipath form (a bare -I
-    # registers an empty path and the next token is misread as a source file),
-    # so the include flag must be a single token with no space.
+    # No -I: incbin's open_file only falls back to the bare path when it has
+    # zero search dirs, so with WORKING_DIRECTORY=<build> it opens the absolute
+    # resource.cpp and the relative luascript.luac (generated in <build>)
+    # directly — same lookup the POSIX .incbin directive uses.
     COMMAND incbin-tool "${CMAKE_CURRENT_SOURCE_DIR}/src/resource.cpp"
-            "-I${CMAKE_CURRENT_SOURCE_DIR}/third-party/incbin"
             -o "${_incbin_data}"
     DEPENDS "${LUASCRIPT_LUAC}" incbin-tool
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
Two CI items:

**1) Windows x86_64 build failure** (`failed to open resource.cpp` → `ninja: build stopped` → `test binary not found`). incbin's `open_file` only falls back to a bare `fopen` when it has **zero** `-I` dirs (`return !count ? fopen(name) : NULL`). The `-I` I added earlier meant it searched only that dir and never opened the absolute `resource.cpp`. Dropping `-I` lets it open the absolute `resource.cpp` and the relative `luascript.luac` (generated in the `WORKING_DIRECTORY` build dir) directly — the same lookup the POSIX `.incbin` directive uses. (MSVC-only path; validated by CI.)

**2) Node 20 deprecation warning** — bump first-party actions to node24 runtimes: `checkout@v5`, `setup-node@v5`, `setup-python@v6`, `setup-java@v5` (inputs unchanged across these majors). `actions/cache@v4` and the third-party `ilammy/msvc-dev-cmd@v1` have no node24 release yet, so they may still warn (non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785001972&installation_id=141995922&pr_number=45&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F45&signature=abfb38bccc6c73db0a82b5a0e71e4d84ac4efa2de26c3e1a1b61bb13299439e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->