### PR TITLE
resource.cpp: guard POSIX template-discovery APIs for MSVC

### DIFF
--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -173,7 +173,7 @@ Resource::GetTemplatePath(const std::string& templateName) noexcept(false) {
 		return globalFilePath;
 	/* source-tree convenience: ./templates/<name> */
 	string localPath("templates/" + templateName);
-	if (0 == access(localPath.c_str(), R_OK))
+	if (readable_(localPath))
 		return localPath;
 	throw ResourceException("Could not open template " + templateName);
 	return std::string("");
@@ -182,19 +182,18 @@ Resource::GetTemplatePath(const std::string& templateName) noexcept(false) {
 string
 Resource::TemplatesDir() noexcept {
 	const char* val = getenv("XSDTOOLS_DATA");
-	if (nullptr != val && 0 == access(val, R_OK))
+	if (nullptr != val && readable_(val))
 		return string(val);
-	struct passwd* pw = getpwuid(getuid());
-	if (nullptr != pw) {
-		string homeDir(pw->pw_dir);
+	string homeDir(homeDir_());
+	if (!homeDir.empty()) {
 		homeDir += "/" + gscHOMEPATH.substr(1);
-		if (0 == access(homeDir.c_str(), R_OK))
+		if (readable_(homeDir))
 			return homeDir;
 	}
-	if (0 == access(gscGLOBALPATH.c_str(), R_OK))
+	if (readable_(gscGLOBALPATH))
 		return gscGLOBALPATH;
 	/* source-tree convenience: ./templates */
-	if (0 == access("templates", R_OK))
+	if (readable_("templates"))
 		return string("templates");
 	return string("");
 }
@@ -205,6 +204,20 @@ Resource::ListTemplates() noexcept {
 	string dir = TemplatesDir();
 	if (dir.empty())
 		return names;
+#if defined(_WIN32)
+	WIN32_FIND_DATAA fd;
+	HANDLE h = FindFirstFileA((dir + "/*").c_str(), &fd);
+	if (INVALID_HANDLE_VALUE == h)
+		return names;
+	do {
+		string name(fd.cFileName);
+		if ("." == name || ".." == name)
+			continue;
+		if (readable_(dir + "/" + name))
+			names.push_back(name);
+	} while (FindNextFileA(h, &fd));
+	FindClose(h);
+#else
 	DIR* pDir = opendir(dir.c_str());
 	if (nullptr == pDir)
 		return names;
@@ -213,10 +226,11 @@ Resource::ListTemplates() noexcept {
 		string name(pEnt->d_name);
 		if ("." == name || ".." == name)
 			continue;
-		if (0 == access((dir + "/" + name).c_str(), R_OK))
+		if (readable_(dir + "/" + name))
 			names.push_back(name);
 	}
 	closedir(pDir);
+#endif
 	sort(names.begin(), names.end());
 	return names;
 }


### PR DESCRIPTION
Fixes the windows-latest compile errors (`R_OK`/`getpwuid`/`getuid`/`opendir`/`readdir`/`closedir`/`DIR`/`dirent` undeclared). `TemplatesDir`/`ListTemplates` bypassed the already-cross-platform `readable_()`/`homeDir_()` helpers and called POSIX directly. Route them through the helpers and add a `_WIN32` `FindFirstFileA` enumeration branch in `ListTemplates` next to the POSIX `opendir` one. POSIX path verified by a clean macOS build; the `_WIN32` branch is CI-validated. Completes A0's Windows portability.

Note: the residual node20 warning is now only `actions/cache@v4` + the third-party `ilammy/msvc-dev-cmd@v1`, neither of which has a node24 release yet — not fixable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785002971&installation_id=141995922&pr_number=46&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F46&signature=a47d316ba66534bce82449a33e525265bdb4f6095e6fb775151127b3fa654439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->