### PR TITLE
src: guard mkdir/access POSIX calls for MSVC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,11 @@
  *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <unistd.h>
+#if defined(_WIN32)
+#	include <io.h>
+#else
+#	include <unistd.h>
+#endif
 #include <exception>
 #include <sstream>
 #include <string>
@@ -97,7 +101,11 @@ int main(int argc, const char* argv[]) {
 
 	/* Distinguish a missing/unreadable XSD up front: Generate() would
 	 * otherwise surface this as a generic parse error. */
+#if defined(_WIN32)
+	if (0 != _access(xsdPath.c_str(), 4 /* R_OK */)) {
+#else
 	if (0 != access(xsdPath.c_str(), R_OK)) {
+#endif
 		cerr << "XSD file not found or unreadable: " << xsdPath << endl;
 		return 3;
 	}

--- a/src/xsdtools.cpp
+++ b/src/xsdtools.cpp
@@ -18,8 +18,12 @@
  *  You should have received a copy of the GNU General Public License
  *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <sys/stat.h>
-#include <sys/types.h>
+#if defined(_WIN32)
+#	include <direct.h>
+#else
+#	include <sys/stat.h>
+#	include <sys/types.h>
+#endif
 #include <cerrno>
 #include <fstream>
 #include <iostream>
@@ -140,7 +144,11 @@ namespace XsdTools {
 
 	std::vector<std::string> SplitMarkedFiles(const std::string& blob,
 	                                          const std::string& outDir) {
+#if defined(_WIN32)
+		if (0 != _mkdir(outDir.c_str()) && EEXIST != errno)
+#else
 		if (0 != mkdir(outDir.c_str(), 0755) && EEXIST != errno)
+#endif
 			throw Core::ResourceException(
 				"Could not create output directory " + outDir);
 		std::vector<std::string> files;


### PR DESCRIPTION
Next Windows compile errors after #46: `xsdtools.cpp(143): mkdir` and (behind it) `main.cpp` `access(R_OK)`. Both are POSIX-only on MSVC. Guard them: `_mkdir` (`<direct.h>`) and `_access(path, 4)` (`<io.h>`) on `_WIN32`, POSIX otherwise. A full `src/` scan confirms these were the last unguarded POSIX calls — so this should clear the POSIX-compile stage on Windows. POSIX path verified by build; `_WIN32` branch CI-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785012230&installation_id=141995922&pr_number=47&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F47&signature=b696926d42b8ca7829b0537e79e5c73bc370d48397d79dc76a7c18a258ce80e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->