### PR TITLE
parser: rename enum values that collide with Windows macros

### DIFF
--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -224,19 +224,19 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		}
 		if (pNode->HasUse()) {
 			switch (pNode->Use()) {
-			case XSD::Elements::Attribute::OPTIONAL:
+			case XSD::Elements::Attribute::Optional:
 				pUse.reset(new string("optional"));
 				break;
-			case XSD::Elements::Attribute::PROHIBITIED:
+			case XSD::Elements::Attribute::Prohibited:
 				pUse.reset(new string("prohibited"));
 				break;
-			case XSD::Elements::Attribute::REQUIRED:
+			case XSD::Elements::Attribute::Required:
 				pUse.reset(new string("required"));
 				break;
 			default:
-				assert(	(pNode->Use() != XSD::Elements::Attribute::OPTIONAL) &&
-						(pNode->Use() != XSD::Elements::Attribute::PROHIBITIED) &&
-						(pNode->Use() != XSD::Elements::Attribute::REQUIRED));
+				assert(	(pNode->Use() != XSD::Elements::Attribute::Optional) &&
+						(pNode->Use() != XSD::Elements::Attribute::Prohibited) &&
+						(pNode->Use() != XSD::Elements::Attribute::Required));
 			}
 		}
 		unique_ptr<LuaAttribute> pAttribute(
@@ -316,7 +316,7 @@ LuaProcessor::ProcessAny(const XSD::Elements::Any* pNode) {
 	/* an any type can be any element in the schema as a child */
 	pNode->ParseChildren(*this);
 	/* if any is strict, then only the elements allowed in the schema doc tree are valid */
-	if (XSD::Elements::Any::STRICT == pNode->ProcessContents()) {
+	if (XSD::Elements::Any::Strict == pNode->ProcessContents()) {
 		ElementExtracter::ElementLst elmLst = pNode->GetAllowedElements();
 		for (	ElementExtracter::ElementLst::iterator itr = elmLst.begin();
 				itr != elmLst.end();

--- a/src/XSDParser/Elements/Any.cpp
+++ b/src/XSDParser/Elements/Any.cpp
@@ -72,7 +72,7 @@ Any::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 Processors::ElementExtracter::ElementLst
 Any::GetAllowedElements() const {
   Processors::ElementExtracter::ElementLst retLst;
-	if (STRICT == ProcessContents()) {
+	if (Strict == ProcessContents()) {
 		Processors::ElementExtracter elmExtrctr;
 		std::unique_ptr<Schema> pDocRoot(Node::GetSchema());
 		retLst = elmExtrctr.Extract(*pDocRoot);
@@ -115,15 +115,15 @@ Any::ProcessContents() const {
 	if (HasProcessContents()) {
 		std::string processContents(Node::GetAttribute<const char*>("processContents"));
 		if (!processContents.compare("lax")) {
-			return Any::LAX;
+			return Any::Lax;
 		} else if (!processContents.compare("skip")) {
-			return Any::SKIP;
+			return Any::Skip;
 		} else if (!processContents.compare("strict")) {
-			return Any::STRICT;
+			return Any::Strict;
 		} else
 			throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttributeValue);
 	}
-	return Any::STRICT;
+	return Any::Strict;
 }
 
 /* static */ Element *

--- a/src/XSDParser/Elements/Any.hpp
+++ b/src/XSDParser/Elements/Any.hpp
@@ -39,9 +39,9 @@ namespace XSD {
 			static Element * findParentElement_(const Node * pNode);
 		public:
 			typedef enum {
-				STRICT,
-				LAX,
-				SKIP
+				Strict,
+				Lax,
+				Skip
 			} ContentValidation;
 			Any(const TiXmlElement& elm, const Parser& rParser);
 			Any(const Any& cpy);

--- a/src/XSDParser/Elements/Attribute.cpp
+++ b/src/XSDParser/Elements/Attribute.cpp
@@ -140,15 +140,15 @@ Attribute::Use() const noexcept(false) {
 	if (HasUse()) {
 		std::string use(Node::GetAttribute<const char*>("use"));
 		if (!use.compare("optional")) {
-			return Attribute::OPTIONAL;
+			return Attribute::Optional;
 		} else if (!use.compare("prohibited")) {
-			return Attribute::PROHIBITIED;
+			return Attribute::Prohibited;
 		} else if (!use.compare("required")) {
-			return Attribute::REQUIRED;
+			return Attribute::Required;
 		} else
 			throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttributeValue);
 	}
-	return Attribute::OPTIONAL;
+	return Attribute::Optional;
 }
 
 			

--- a/src/XSDParser/Elements/Attribute.hpp
+++ b/src/XSDParser/Elements/Attribute.hpp
@@ -41,9 +41,9 @@ namespace XSD {
 			static Types::BaseType* parseType_(const Attribute& rAttrib) noexcept(false);;
 		public:
 			typedef enum {
-				OPTIONAL,
-				PROHIBITIED,
-				REQUIRED
+				Optional,
+				Prohibited,
+				Required
 			} AttributeUse;
 			Attribute(const TiXmlElement& elm, const Parser& rParser);
 			Attribute(const Attribute& rAttrib);


### PR DESCRIPTION
Next windows-latest compile cascade (`Any.hpp(42): C2059: syntax error: 'constant'`). Root cause: `windows.h` (via boost on MSVC) `#define`s `STRICT` and `OPTIONAL`, which collide with the `Any::ContentValidation {STRICT,LAX,SKIP}` and `Attribute::AttributeUse {OPTIONAL,PROHIBITIED,REQUIRED}` enumerators — the preprocessor rewrites the enum tokens. Rename to collision-free PascalCase (`Strict/Lax/Skip`, `Optional/Prohibited/Required`; also fixes the `PROHIBITIED` typo). Pure rename across Any/Attribute + the LuaProcessor usages — behavior-identical, goldens unchanged, gating suite green. A scan of `src/` for other common Windows-macro identifiers came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013193&installation_id=141995922&pr_number=48&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F48&signature=08576d355a14f08175a538d92e5271b835d2260f5a416b283e0a6ae180dcd51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->