### PR TITLE
parser: drop dead <unistd.h> include from Include/Import

### DIFF
--- a/src/XSDParser/Elements/Import.cpp
+++ b/src/XSDParser/Elements/Import.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <memory>
-#include <unistd.h>
 #include "./src/XSDParser/Elements/Import.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"

--- a/src/XSDParser/Elements/Include.cpp
+++ b/src/XSDParser/Elements/Include.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <memory>
-#include <unistd.h>
 #include "./src/XSDParser/Elements/Include.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"


### PR DESCRIPTION
Next windows-latest error: `Include.cpp(25)` / `Import.cpp(25)` `C1083: Cannot open include file 'unistd.h'`. Both included `<unistd.h>` but use nothing from it — a leftover after E2 moved schemaLocation resolution into `Node::resolveSchemaURI_`. No MSVC equivalent needed; just remove the dead include. POSIX path verified by clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785017466&installation_id=141995922&pr_number=49&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F49&signature=ce7345d44133b798fb4d8f3bd617213e6f2374db7fdff18fe5f2c6adcb2f1b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->