### PR TITLE
test: guard unsetenv for MSVC in resourceTests

### DIFF
--- a/test/resourceTests.cpp
+++ b/test/resourceTests.cpp
@@ -24,7 +24,11 @@ TEST(Resource, ResolvesAbsoluteTemplatePath) {
 
 TEST(Resource, ThrowsOnMissingTemplate) {
 	/* clear the env override so the search falls through to a throw */
+#if defined(_WIN32)
+	_putenv("XSDTOOLS_DATA=");
+#else
 	unsetenv("XSDTOOLS_DATA");
+#endif
 	Core::Resource resource;
 	EXPECT_THROW(resource.GetTemplatePath("xsdb-no-such-template-xyz"),
 	             Core::ResourceException);


### PR DESCRIPTION
Last POSIX call in the Windows test subset: `resourceTests.cpp(27): unsetenv` (clears XSDTOOLS_DATA for the missing-template throw test). MSVC has no `unsetenv`; use `_putenv("XSDTOOLS_DATA=")` on `_WIN32`. POSIX path verified by build + Resource.* tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785019707&installation_id=141995922&pr_number=51&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F51&signature=ea236c3185e8df5dc316648df825f037ed446a9063a45859acfc4727d8909dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->