### PR TITLE
cmake: pass -p _binary_ to incbin (MSVC link)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,11 @@ if(MSVC)
     # zero search dirs, so with WORKING_DIRECTORY=<build> it opens the absolute
     # resource.cpp and the relative luascript.luac (generated in <build>)
     # directly — same lookup the POSIX .incbin directive uses.
+    # -p _binary_ matches INCBIN_PREFIX below so the emitted data symbols
+    # (_binary_luascript_luacData/Size) resolve resource.cpp's externs;
+    # incbin's default prefix is "g", which would not match.
     COMMAND incbin-tool "${CMAKE_CURRENT_SOURCE_DIR}/src/resource.cpp"
+            -p _binary_
             -o "${_incbin_data}"
     DEPENDS "${LUASCRIPT_LUAC}" incbin-tool
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
Windows compiles fully now and reaches **link**, failing with `unresolved external _binary_luascript_luacData/_binary_luascript_luacSize`. resource.cpp declares those via `INCBIN` with `INCBIN_PREFIX=_binary_`, but `incbin-tool` emitted the data symbols with its **default prefix `g`** (`gluascript_luac…`). Pass `-p _binary_` so the generated symbols match. MSVC-only path (POSIX uses the assembler `.incbin` directive), CI-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785020607&installation_id=141995922&pr_number=52&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F52&signature=88698f198233e377598066b2a381632770ce8f80b7c4701e4584d023af2f1c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->