### PR TITLE
docs: per-target guides + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,29 @@ xsd-tools is a set of tools for generating code from xml xsd schema documents, m
 
 It ships output targets covering the C / C++ / Python / Java / TypeScript languages, all round-trip tested:
 
-| Target template      | Language | Format | Library          |
-|----------------------|----------|--------|------------------|
-| `c-xml-expat`        | C        | XML    | expat            |
-| `c-json-jsonc`       | C        | JSON   | json-c           |
-| `cpp-xml-expat`      | C++11    | XML    | expat            |
-| `cpp-json-jsonc`     | C++11    | JSON   | json-c           |
-| `python-sax`         | Python   | XML    | stdlib `xml.sax` |
-| `python-json.tmpl`   | Python   | JSON   | stdlib `json`    |
-| `java-json.org.tmpl` | Java     | JSON   | org.json         |
-| `java-xml-stax.tmpl` | Java     | XML    | JDK StAX         |
-| `ts-xml.tmpl`        | TypeScript | XML  | fast-xml-parser  |
+| Target template      | Language   | Format   | Library          | Guide |
+|----------------------|------------|----------|------------------|-------|
+| `c-xml-expat`        | C          | XML      | expat            | [docs](docs/templates/c-xml-expat.md) |
+| `c-xml-expat-dom`    | C          | XML (DOM)| expat            | [docs](docs/templates/c-xml-expat-dom.md) |
+| `c-json-jsonc`       | C          | JSON     | json-c           | [docs](docs/templates/c-json-jsonc.md) |
+| `cpp-xml-expat`      | C++11      | XML      | expat            | [docs](docs/templates/cpp-xml-expat.md) |
+| `cpp-json-jsonc`     | C++11      | JSON     | json-c           | [docs](docs/templates/cpp-json-jsonc.md) |
+| `python-sax`         | Python     | XML      | stdlib `xml.sax` | [docs](docs/templates/python-sax.md) |
+| `python-json.tmpl`   | Python     | JSON     | stdlib `json`    | [docs](docs/templates/python-json.md) |
+| `java-json.org.tmpl` | Java       | JSON     | org.json         | [docs](docs/templates/java-json.md) |
+| `java-xml-stax.tmpl` | Java       | XML      | JDK StAX         | [docs](docs/templates/java-xml-stax.md) |
+| `ts-xml.tmpl`        | TypeScript | XML      | fast-xml-parser  | [docs](docs/templates/ts-xml.md) |
 
-Generated code constructs schema types through overridable factory methods, so consumers can subclass and inject custom types.
+Per-target guides (generate command, toolchain, generated API, examples) live
+under [`docs/templates/`](docs/templates/).
 
-It processes XSD schema documents and invokes a template file which outputs code. The templates files use Lua for scripting withing the template file. Custom user templates can be easily be created to extend the tool to generate different output code.
+Most targets construct schema types through overridable factory methods, so consumers can subclass and inject custom types (the `java-json.org` target constructs nested types directly) — see each target's guide for the exact mechanism.
+
+It processes XSD schema documents and invokes a template file which outputs code. The templates files use Lua for scripting within the template file. Custom user templates can be easily be created to extend the tool to generate different output code.
 
 ### Features ###
   * XSD schema parsing
-  * Nine built-in output targets across C/C++/Python/Java/TypeScript,
+  * Ten built-in output targets across C/C++/Python/Java/TypeScript,
     easily extendable
   * Generated unmarshallers enforce XSD restriction facets at parse time
     (range, length, enumeration on elements and attributes) — invalid documents
@@ -35,115 +39,16 @@ It processes XSD schema documents and invokes a template file which outputs code
   * Usable as a C++ library (`XsdTools::Generate()`) as well as a CLI.
   * Open Source!
 
-_Look at the Wiki section for more information._
-
 Namespaces are supported: schemas with a `targetNamespace` resolve and the XML
 targets emit the right `xmlns`/prefixes, and `xs:import` brings in types from
 another namespace (`xs:include` continues to merge same-namespace documents).
 
 ### Sample Output ###
-```
-# xsdb python-sax test/xsd-positive/testA002.xsd
+Each [per-target guide](docs/templates/) shows real generated output and a
+marshal/unmarshal example for that target. For a quick look without reading a
+guide, just run the tool — e.g. `xsdb python-sax test/xsd-positive/testA002.xsd`
+prints the generated Python to stdout.
 
-
-import cStringIO
-import xml.sax
-
-class _handler(xml.sax.ContentHandler):
-        _elemTbl = {
-                'myElem':lambda: xml_myElem(),
-                'foo':lambda: xml_foo(),
-        }
-        def __init__(self):
-                xml.sax.ContentHandler.__init__(self)
-                return
-        # methods inherited from xml.sax.ContentHandler
-        def startDocument(self):
-                self._elemStk = [("testA021", {}, [])]
-                return
-        def startElementNS(self, name, qname, SAXAttributes):
-                element = _handler._elemTbl[name[1]]()
-                elementRecord = (element, self._convertToDictionary(SAXAttributes),  [])
-                self._elemStk[-1][2].append(element)    
-                self._elemStk.append(elementRecord)        
-                return
-        def characters(self, content): 
-                if self._elemStk[-1][2] and isinstance(self._elemStk[-1][2][-1], basestring):
-                        self._elemStk[-1][2][-1] = self._elemStk[-1][2][-1] + content;
-                else:
-                        self._elemStk[-1][2].append(content)
-                return
-        def endElementNS(self, name, qname):
-                elementRecord = self._elemStk.pop()
-                elementRecord[0].unmarshall(elementRecord[1], elementRecord[2])
-                return
-        @staticmethod
-        def _convertToDictionary(SAXAttributes):
-                return {k: SAXAttributes.getValueByQName(k) for k in SAXAttributes.getQNames() }
-
-class _xmlelement:
-        def __init__(self):
-                self._content = []
-                return
-        def getContent(self):
-                return self._content
-
-class xml_myElem(_xmlelement):
-        def __init__(self):
-                _xmlelement.__init__(self)
-                return
-        def marshall(self, stream):
-                stream.write('<myElem')
-                stream.write('>')
-                for node in self.getContent():
-                        if isinstance(node, _xmlelement):
-                                node.marshall(stream)
-                        else:
-                                stream.write(str(node))
-                stream.write('</myElem>')
-                return
-        def unmarshall(self, attributes, content):
-                self._content = content
-                return
-
-class xml_foo(_xmlelement):
-        def __init__(self):
-                _xmlelement.__init__(self)
-                return
-        def marshall(self, stream):
-                stream.write('<foo')
-                stream.write('>')
-                for node in self.getContent():
-                        if isinstance(node, _xmlelement):
-                                node.marshall(stream)
-                        else:
-                                stream.write(str(node))
-                stream.write('</foo>')
-                return
-        def unmarshall(self, attributes, content):
-                self._content = content
-                return
-
-
-
-class xml_testA002(_handler, _xmlelement):
-        def __init__(self):
-                _handler.__init__(self)
-                _xmlelement.__init__(self)
-                return
-        def marshall(self, stream):
-                stream.write("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n")
-                for elm in self.getContent():
-                        elm.marshall(stream)
-                return
-        def unmarshall(self, stream):
-                parser = xml.sax.make_parser()
-                parser.setFeature(xml.sax.handler.feature_namespaces, 1)
-                parser.setContentHandler(self)
-                parser.parse(stream)
-                self._content = self._elemStk[-1][2]
-                return
-```
 ### Usage Guide ###
 
 To use xsd-tools, invoke xsdb using the following syntax from the console
@@ -190,8 +95,11 @@ the recipe's LNUM patch, so `patch` must be on the host.
   * a C++11 compiler (gcc/clang/MSVC)
   * Lua **5.1** (library + `luac`) — newer Lua will not work
   * tinyxml, expat, boost (system + filesystem)
-  * python3 (build-time test generation; runtime for the python round-trip)
+  * python3 (build-time test generation; runtime for the python round-trips)
   * conan (`pip install 'conan<2'`) for the dependency path below
+  * json-c (the C/JSON target; fetched automatically if not found)
+  * optional test toolchains — the round-trip tests skip when these are
+    absent: a JDK + Maven (Java targets), node + npm (the `ts-xml` target)
 
 On ubuntu the system packages are:
 ```
@@ -216,9 +124,14 @@ Equivalently, by hand:
 config at build time with `--config`.
 
 #### Testing ####
+Run the gtest binary directly (project convention — not ctest):
 ```
-   ctest --test-dir build -C Release --output-on-failure
+   build/test/xsdb-test                                # all tests
+   build/test/xsdb-test --gtest_filter='Parser.*'      # a subset
+   python3 test/run_parallel.py --binary build/test/xsdb-test  # sharded, faster
 ```
+The round-trip tests shell out to each target's toolchain (cc, python3, mvn/java,
+node/tsc) and **skip** cleanly when a toolchain is absent.
 
 #### Installing / Uninstalling ####
 ```

--- a/docs/templates/c-json-jsonc.md
+++ b/docs/templates/c-json-jsonc.md
@@ -1,0 +1,195 @@
+# c-json-jsonc
+
+Generates C marshalling/unmarshalling code that maps an XSD schema onto JSON,
+using [json-c](https://github.com/json-c/json-c) for the JSON DOM.
+
+## Generate
+
+```sh
+# print all files to stdout (separated by /* FILE: name */ markers)
+xsdb c-json-jsonc.template schema.xsd
+
+# split the marked output into real files under build/
+xsdb --out-dir build c-json-jsonc.template schema.xsd
+```
+
+A schema named `schema.xsd` produces three files:
+
+- `json_common.h` — shared `json_buffer` type, helper macros.
+- `json_schema.h` — per-element structs, the `json_marshaller`, the factory
+  table, and the public marshal/unmarshal prototypes.
+- `json_schema.c` — the implementation.
+
+The schema name is the root type with a trailing `_xsd` stripped (e.g.
+`testA026.xsd` → `testA026`).
+
+## Toolchain & dependencies
+
+- A C11 compiler. The round-trip test harness compiles the generated code with
+  the project C compiler at `-std=c11`.
+- **json-c** — the generated `.c` includes `<json.h>` and links `libjson-c`.
+- **libb64** — only required when the schema uses `base64Binary` or `hexBinary`;
+  the generated `.c` then includes `b64/cencode.h` / `b64/cdecode.h` and must
+  link libb64.
+
+## Generated API
+
+### Type model
+
+Each XSD element becomes a `json_<name>` struct. Attributes and element content
+are struct members; the content member is always named `Content_`. Members are
+suffixed `_`; string (`char*`) members are additionally `p`-prefixed
+(`pattrib1Required_`). XSD scalar types map to fixed-width C types
+(`integer`→`int64_t`, `int`→`int32_t`, `boolean`→`int`, `string`→`char*`,
+`decimal`→`long double`, …). An element that has child elements (or is otherwise
+empty) carries a `uint32_t eid_` filler, used to seed children's `parentId`.
+
+```c
+typedef struct {
+	uint32_t	eid_;
+	int64_t		attrib2Optional_;
+	char*		pattrib1Required_;
+	char*		pattrib1Optional_;
+	int64_t		attrib2Required_;
+} json_foo;
+```
+
+### Overridable factory
+
+`json_<schema>_factories` holds an Allocator / Constructor / Destructor triple
+per element type. Every element struct on the unmarshal path is allocated,
+constructed, and destroyed through this triple, so a caller can inject custom
+construction by supplying their own table to `json_unmarshal_ex`. The dispatch
+is NULL-safe: a NULL table, or any NULL member, falls back to the defaults
+(zeroed `malloc` allocate, no-op construct, `realloc(p,0)` free). The default
+table is returned by `json_<schema>_default_factories()`; the default
+Constructor pointer is NULL (no-op).
+
+### json-c build / parse
+
+Per element, `build_<name>_()` creates a fresh `json_object` and adds each
+attribute under its own key and the content under the key `"$"`. Numbers use
+`json_object_new_int64` / `_double`, strings `json_object_new_string`. Unmarshal
+reads back with `json_object_object_get_ex` + `json_object_get_*`.
+
+### Marshal / unmarshal entry points
+
+```c
+json_marshal_<schema>_xsd json_marshal(json_marshaller* pMarshaller);
+json_buffer json_marshal_flush(json_marshaller* pMarshaller, int isDocEnd);
+void json_unmarshal(json_marshaller* pMarshaller, const json_buffer* pBuf,
+                    int isDocEnd);
+void json_unmarshal_ex(json_marshaller* pMarshaller, const json_buffer* pBuf,
+                       int isDocEnd, const json_<schema>_factories* pFactories);
+```
+
+`json_marshal` returns a struct of `marshal_<child>` function pointers plus the
+parent `json_object* pSelf`; you walk the tree by calling a child's marshaller
+with its parent's `pSelf`, which (for non-leaf children) returns the next level
+of marshallers. `json_marshal_flush` serializes the root to a `json_buffer` and,
+when `isDocEnd` is set, releases the root. Unmarshalling is push-style: you
+populate `json_marshaller`'s `unmarshal_<name>` callbacks; the parser calls each
+callback with a fully-populated, stack-lifetime `json_<name>*` and the parent's
+`eid_`. The object is destroyed immediately after the callback returns — copy
+out anything you need to keep. `realloc` on the marshaller is the single
+required hook (allocator for the whole pipeline).
+
+### Facet validation
+
+For an element whose content/attributes carry restriction facets, a
+`static int validate_<name>_(const json_<name>*)` is emitted, returning non-zero
+on violation. Numeric `minInclusive`/`maxInclusive` become a range check;
+string `length`/`min`/`maxLength` become a `strlen` check; enumerations switch
+on the seed-0 SDBM hash of the value (strcmp-confirmed on hash collision). On the
+unmarshal path the validation guards only the notify callback: an invalid object
+is **silently skipped** (the `unmarshal_<name>` callback never fires) but is
+still destroyed normally. Marshalling does not validate. Pattern facets are not
+enforced. Integer ranges with both bounds known also narrow the C member to the
+smallest fixed-width int that holds the range (the `1..5` `integer` below becomes
+`uint8_t`).
+
+### base64 / hex / list
+
+`base64Binary` → `json_base64`, `hexBinary` → `json_hex` (both
+`{ uint8_t* pBuffer_; uint32_t size_; }`); base64 marshals through libb64's
+`base64_encode_block` to a JSON string, hex similarly. An XSD `list` becomes a
+`json_<base>List` struct (`{ <base>* pArray_; uint32_t nElements_; }`) marshalled
+as a JSON array.
+
+## Example
+
+`rating.xsd`:
+
+```xml
+<schema>
+	<element name="rating" type="ratingType" />
+	<simpleType name="ratingType">
+		<restriction base="integer">
+			<minInclusive value="1"/>
+			<maxInclusive value="5"/>
+		</restriction>
+	</simpleType>
+</schema>
+```
+
+```sh
+xsdb --out-dir build c-json-jsonc.template rating.xsd
+```
+
+The range narrows the member to `uint8_t` and emits a validator:
+
+```c
+typedef struct {
+	uint8_t	Content_;
+} json_rating;
+
+static int validate_rating_(const json_rating* pObj) {
+	if (!((pObj->Content_) >= 1 && (pObj->Content_) <= 5))
+		return -1;
+	return 0;
+}
+```
+
+Driving marshal then unmarshal:
+
+```c
+static void* rc(struct json_marshaller* m, void* p, size_t s) {
+	(void)m; return realloc(p, s);
+}
+static void on_rating(struct json_marshaller* m, const json_rating* o,
+                      uint32_t parent) {
+	(void)m; (void)parent;
+	printf("rating = %u\n", o->Content_);   /* not called if out of 1..5 */
+}
+
+int main(void) {
+	json_marshaller m = { .realloc = rc, .unmarshal_rating = on_rating };
+	json_rating r = { .Content_ = 3 };
+
+	json_marshal_rating_xsd s = json_marshal(&m);
+	s.marshal_rating(&m, &r, s.pSelf);
+	json_buffer out = json_marshal_flush(&m, 1);
+
+	json_unmarshal(&m, &out, 1);          /* fires on_rating with 3 */
+	out.pBuf_ = rc(&m, out.pBuf_, 0);
+	return 0;
+}
+```
+
+## Notes
+
+- **JSON has no attribute/element distinction.** Attributes and child elements
+  alike become object keys; element *content* (simple-type text) is stored under
+  the reserved key `"$"`. A schema that uses `"$"` as an attribute name would
+  collide.
+- **Unmarshal is push/callback-style and objects are transient.** The
+  `json_<name>*` handed to your callback is freed as soon as the callback
+  returns; deep-copy anything you keep.
+- **Attribute defaults** are applied before reading the JSON: the default is
+  parsed as a JSON literal and assigned, then overwritten if the key is present.
+- **Invalid values are dropped, not reported.** Facet validation failure skips
+  the notify callback with no error signal; there is no way to distinguish "field
+  absent" from "field present but invalid" at the callback boundary.
+- Adding a new output target is template-only — no C++ change. This target lives
+  in `templates/c-json-jsonc.template` plus the per-type subtemplates under
+  `templates/c-json-jsonc/`.

--- a/docs/templates/c-xml-expat-dom.md
+++ b/docs/templates/c-xml-expat-dom.md
@@ -1,0 +1,152 @@
+# c-xml-expat-dom
+
+C marshaller/unmarshaller for **XML** built on the **expat** parser, **DOM
+style**: unmarshalling builds an in-memory document tree (`xml_typelist`) that
+you traverse and can re-marshal whole. Scalars that fit in a pointer are stored
+**inline** in the tree slot (no per-scalar heap allocation). For the
+streaming/event variant see [c-xml-expat](c-xml-expat.md).
+
+## Generate
+
+The DOM target's main template has a `.template` extension:
+
+```sh
+build/xsdb c-xml-expat-dom.template test/xsd-positive/testA026.xsd      # stdout
+build/xsdb --out-dir out/ c-xml-expat-dom.template test/xsd-positive/testA026.xsd
+# -> out/xml_testA026.h  out/xml_testA026.c
+```
+
+Output is split on `/* FILE: */` markers (`xml_<schema>.h`, `xml_<schema>.c`).
+
+## Toolchain & dependencies
+
+- A C compiler (round-trip harness uses `C_COMPILER` at **`-std=c11`**).
+- Link against **expat** (`<expat.h>`, `-lexpat`).
+- **libb64** is always pulled in here — the `.c` unconditionally
+  `#include`s `b64/cencode.h` / `b64/cdecode.h`, so link the libb64 archive
+  even for schemas without base64/hex.
+- Standard headers used: `<inttypes.h>`, `<ctype.h>`, `<alloca.h>`.
+
+Harness flow (`test/roundtrip_util.cpp`, `cExpatDomRoundtrip`): generate
+binding + `c-xml-expat-dom.template-test` driver, split, then
+`cc -std=c11 -I<dir> -I<libb64> <base>-bin.c xml_<base>.c <libb64.a> <expat>`
+and run.
+
+## Generated API
+
+**Type model (the DOM tree).** The universal node is:
+
+```c
+typedef struct { unsigned type_; void* pData_; } xml_typelist;
+```
+
+A document is a `type_`-tagged, sentinel-terminated (`{0,NULL}`) array of these.
+`type_` is a per-type enum (`XML_FOO`, `XML_NAME`, `XML_STRING`, ... — values
+are `sdbm` type hashes). Each complex element is a heap struct whose `pContent_`
+is itself an `xml_typelist*` child array, e.g.:
+
+```c
+typedef struct xml_foo {
+    xml_typelist* pContent_;
+    xml_integer   attrib2Optional;   /* int64_t */
+    xml_integer   attrib2Required;
+    xml_string    attrib1Optional;   /* char*   */
+    xml_string    attrib1Required;
+} * xml_foo;            /* note: the typedef is a POINTER */
+```
+
+**Inline scalar storage (the key difference vs SAX).** A scalar whose
+`sizeof <= sizeof(void*)` is stored **directly in the `xml_typelist.pData_`
+slot** via `memcpy` — no malloc per scalar. A wider scalar (e.g. a 64-bit value
+on a 32-bit target) falls back to heap, with the slot holding the pointer.
+`sizeof` folds the choice at compile time (`XML_SCALAR_FITS_`,
+`XML_SCALAR_ENCODE_`/`LOAD_`/`FREE_`). The dispatch tables in
+`xml_typelist_marshal_` / `xml_destroy` choose `MarshalContentScalar` /
+`DestroyScalar` (pass the slot straight through) vs `MarshalContent` /
+`Destroy` (cast the pointer) per type — `ctype:inlineScalar()` decides. Scalar
+**attributes** that are required or have a default are stored by value;
+optional-no-default scalar attributes keep a nullable pointer.
+
+**Factory (Allocator/Constructor/Destructor triple).** `xml_typeFactory` holds
+`xml_realloc(F, ptr, size, file, line)` plus, per element type, an
+`xml_<name>Allocator` / `Constructor` / `Destructor`. NULL-safe via
+`ReallocateMemory` / `AllocateElement` / `ConstructElement` / `DestroyElement`:
+a missing factory or member falls back to `realloc`/`alloc_`/no-op.
+
+**Marshal / unmarshal entry points** (the only three public functions):
+
+```c
+xml_typelist* xml_unmarshal(const char* pBuf, size_t size, const xml_typeFactory*);
+char*         xml_marshal(const xml_typelist* pDoc, const xml_typeFactory*);
+void          xml_destroy(xml_typelist** ppDoc, const xml_typeFactory*);
+```
+
+`xml_unmarshal` runs expat over the whole buffer in one shot (not streaming) and
+returns the root node; the callbacks `startElement_`/`endElement_`/
+`elementContent_` build the tree on an `xml_context_t_` stack (fixed depth =
+schema's max element depth). `xml_marshal` walks the tree and returns a freshly
+`malloc`'d `char*` (plain buffer, no hidden header — `free()` it). `xml_destroy`
+tears the tree down through the factory.
+
+**Facet validation.** Range / length / enum checks are emitted inline in
+`endElement_` (via `c_facetChecks`) on the element's content string. **On
+violation it calls `xml_invalid_`, which prints
+`xml: facet violation (<label>)` to stderr and `exit(1)`s** — a hard abort, no
+recovery. Pattern facets are skipped. Numeric enums/ranges are checked against
+the `atoll`-parsed value, string enums via a collision-safe `sdbm` switch.
+
+**Namespaces.** Gated on `targetNamespace`; non-namespaced schemas are
+unchanged. A deterministic synthesized prefix (`c_nsTagName`/`namespace`
+template) is used since the XSD source prefix isn't in the model — qualified
+nodes are emitted `prefix:name` with `xmlns:` declared on the root; an
+unqualified root binds the default `xmlns`. Element dispatch hashes the wire tag
+(prefixed when qualified); hash collisions add a `strcmp` confirm.
+
+**base64/hex & lists.** `base64Binary`/`hexBinary` use libb64 codecs.
+`list`-typed values get a `xml_list_t_` growable array + a whitespace tokenizer
+(`tokenizer_*`); the content list is sentinel-terminated.
+
+## Example
+
+```sh
+build/xsdb --out-dir out/ c-xml-expat-dom.template test/xsd-positive/testA026.xsd
+```
+
+Unmarshal, traverse, re-marshal, destroy:
+
+```c
+xml_typelist* doc = xml_unmarshal(xml_text, len, NULL);  /* NULL = default factory */
+
+for (xml_typelist* p = doc; p->type_; ++p) {
+    if (p->type_ == XML_FOO) {
+        xml_foo foo = (xml_foo)p->pData_;
+        /* foo->attrib2Required is an int64_t read inline from the slot;
+           foo->attrib1Required is a char*; foo->pContent_ is the child array */
+    }
+}
+
+char* xml = xml_marshal(doc, NULL);   /* re-serialize; free(xml) when done */
+free(xml);
+xml_destroy(&doc, NULL);
+```
+
+To build a tree for marshalling by hand, populate `xml_foo` structs, point each
+`pContent_` at a `{0,NULL}`-terminated `xml_typelist` child array, and pass the
+root array to `xml_marshal`.
+
+## Notes
+
+- `xml_unmarshal` parses the **entire** buffer at once — it is not a streaming
+  API (unlike SAX's chunked `xml_unmarshal`).
+- The parse stack is a fixed-size array sized to the schema's max element depth;
+  documents nested deeper than the schema allows are not supported.
+- Element/attribute typedefs are **pointer** types (`xml_foo` is
+  `struct xml_foo *`).
+- Facet violations call `exit(1)`; don't feed untrusted input expecting graceful
+  failure.
+- libb64 is linked unconditionally for this target, even without base64/hex.
+- **DOM vs SAX:** pick **c-xml-expat-dom** when you want the full document in
+  memory as a navigable `xml_typelist` tree (random access, whole-document
+  re-marshal, inline scalar storage minimizing allocations). Pick
+  [c-xml-expat](c-xml-expat.md) for streaming / low-memory parsing where you
+  handle each element via a callback as it closes.

--- a/docs/templates/c-xml-expat.md
+++ b/docs/templates/c-xml-expat.md
@@ -1,0 +1,153 @@
+# c-xml-expat
+
+C marshaller/unmarshaller for **XML** built on the **expat** SAX parser. This is
+the **SAX-style** target: unmarshalling is event-driven — element structs are
+filled on `expat` start/end/character callbacks and handed to your code one at a
+time. No document tree is built. For the tree-building variant see
+[c-xml-expat-dom](c-xml-expat-dom.md).
+
+## Generate
+
+Single-file to stdout:
+
+```sh
+build/xsdb c-xml-expat test/xsd-positive/testA026.xsd
+```
+
+The output is one stream containing three `/* FILE: */`-marked units
+(`xml_common.h`, `xml_<schema>.h`, `xml_<schema>.c`). Split it to disk with
+`--out-dir`:
+
+```sh
+build/xsdb --out-dir out/ c-xml-expat test/xsd-positive/testA026.xsd
+# -> out/xml_common.h  out/xml_testA026.h  out/xml_testA026.c
+```
+
+(`csplit - '/\/\* FILE: /' {*}` does the same from a piped stream.)
+
+## Toolchain & dependencies
+
+- A C compiler (round-trip harness uses the project `C_COMPILER` at
+  **`-std=c11`**).
+- Link against **expat** (`#include <expat.h>`, `-lexpat`).
+- **libb64** only when the schema uses `base64Binary`/`hexBinary` — the `.c`
+  then `#include`s `b64/cencode.h` / `b64/cdecode.h` and you link the libb64
+  archive.
+
+Harness flow (`test/roundtrip_util.cpp`, `cExpatRoundtrip`): generate the
+binding + the `c-xml-expat-test` driver, `SplitMarkedFiles` into a temp dir,
+then `cc -std=c11 -I<dir> -I<libb64> <base>-bin.c xml_<base>.c <libb64.a>
+<expat>` and run.
+
+## Generated API
+
+**Type model.** Each non-root element becomes a flat C struct `xml_<name>` with
+a `uint32_t eid_` id, one field per attribute, and (for simple-content
+elements) a `Content` field. Scalars use fixed C types (`int64_t` for
+`integer`, `char*` for `string`, etc.); strings are `char*` (`p`-prefixed
+field names). Example from `testA026.xsd`:
+
+```c
+typedef struct { uint32_t eid_; char* pContent_; } xml_name;
+typedef struct {
+    uint32_t eid_;
+    int64_t  attrib2Optional_;
+    char*    pattrib1Required_;
+    char*    pattrib1Optional_;
+    int64_t  attrib2Required_;
+} xml_foo;
+```
+
+**Factory (Allocator/Constructor/Destructor triple).** `xml_typeFactory` holds
+an `xml_realloc` plus, per element type, an `xml_<name>Allocator` /
+`Constructor` / `Destructor`. All are optional: a NULL factory or NULL member
+falls back to **in-place** construction (element structs live by value inside
+the parse-stack record, so the default Allocator returns the in-place pointer
+rather than heap-allocating) and scalar free. Dispatched through the NULL-safe
+`AllocateElement` / `ConstructElement` / `DestroyElement` macros.
+
+**Marshal (serialize).** `xml_marshal(xml_marshaller*)` returns a struct of
+function pointers (`xml_marshal_<root>`) that you call top-down to walk into
+child elements; leaf children get a `void` `marshal_<name>` pointer, branch
+children return their own nested function-pointer struct. Each call appends the
+element's start tag + attributes + content to an internal buffer.
+`xml_marshal_flush(m, isDocEnd)` returns the accumulated `xml_buffer` (and on
+`isDocEnd` closes any still-open tags via `marshal_adjustElmStk_`). The
+marshaller is stack-driven: open tags are closed lazily when a sibling/parent
+of a different element type is emitted.
+
+**Unmarshal (parse).** `xml_unmarshal(m, &buf, isDocEnd)` feeds bytes to expat;
+call repeatedly for streaming, with `isDocEnd != 0` on the last chunk (it then
+frees the parser). You supply per-element callbacks
+`m->unmarshal_<name>(m, const xml_<name>* pObj, uint32_t parent)` that fire on
+each element's **end** tag, receiving the fully-populated struct and its
+parent's id. Element dispatch is by `sdbm` hash of the (prefix-stripped) tag
+name; attributes likewise. Attribute `default`s are pre-applied before the
+attribute loop overwrites them.
+
+**Facet validation.** When an element's content or an attribute carries facets
+(range / length / enum), a `validate_<name>_` function is emitted and invoked in
+`prsElmRec_invoke_` before your callback. **On an invalid value it prints
+`<name>: facet validation failed` to stderr and `abort()`s** — there is no
+soft-error path. Pattern facets are not checked.
+
+**Namespaces.** All NS emission is gated on the schema having a
+`targetNamespace`; non-namespaced schemas are byte-identical to before the NS
+feature. When present, a single `tns` prefix is declared via
+`xmlns:tns="<uri>"` on the document-root start tag, and qualified
+elements/attributes are emitted as `tns:name`. On unmarshal expat is created
+NS-aware (separator `':'`) and tags/attrs are matched on the **local** name
+(prefix stripped via `strrchr(..., ':')`).
+
+**base64/hex & lists.** `base64Binary`/`hexBinary` pull in libb64 and get
+dedicated codec functions. `list`-typed values get list marshal/unmarshal
+helpers; the type table separates list from non-list C types deterministically
+(sorted by C type name) so output is reproducible.
+
+## Example
+
+Schema (`testA026.xsd`): a `foo` element with four attributes (two with
+defaults, two required) and an optional `name` child.
+
+```sh
+build/xsdb --out-dir out/ c-xml-expat test/xsd-positive/testA026.xsd
+```
+
+Marshal:
+
+```c
+xml_marshaller m = { .realloc = my_realloc };
+xml_marshal_testA026_xsd root = xml_marshal(&m);
+xml_foo foo = { .eid_ = 1, .attrib1Required_ = "r",
+                .attrib2Required_ = 7, .attrib1Optional_ = "o",
+                .attrib2Optional_ = 5 };
+xml_marshal_foo f = root.marshal_foo(&m, &foo);
+xml_name nm = { .pContent_ = "hi" };
+f.marshal_name(&m, &nm);
+xml_buffer out = xml_marshal_flush(&m, 1);   /* out.pBuf_ = the XML text */
+```
+
+Unmarshal:
+
+```c
+void on_foo(xml_marshaller* m, const xml_foo* o, uint32_t parent) { /* use o */ }
+xml_marshaller m = { .realloc = my_realloc, .unmarshal_foo = on_foo };
+xml_buffer in = { (uint8_t*)xml_text, 0, (uint32_t)len };
+xml_unmarshal(&m, &in, 1);   /* fires on_foo at </foo> */
+```
+
+You must supply `m.realloc` (and may supply `m.pFactory_`).
+
+## Notes
+
+- Element structs are embedded by value in the parse stack, so the default
+  (factory-less) path does no per-element heap allocation; only `char*`
+  attributes/content are heap-copied.
+- Marshalling closes tags lazily — you must call `xml_marshal_flush(m, 1)` at
+  document end to emit the final closing tags.
+- Facet violations **abort the process**; do not feed untrusted input expecting
+  graceful failure.
+- **SAX vs DOM:** pick **c-xml-expat** when you want low memory / streaming and
+  are happy to handle elements via callbacks as they close. Pick
+  [c-xml-expat-dom](c-xml-expat-dom.md) when you want the whole document as an
+  in-memory `xml_typelist` tree you can traverse and re-marshal.

--- a/docs/templates/cpp-json-jsonc.md
+++ b/docs/templates/cpp-json-jsonc.md
@@ -1,0 +1,162 @@
+# cpp-json-jsonc
+
+Modern C++11 marshalling/unmarshalling to and from JSON, built on the
+[json-c](https://github.com/json-c/json-c) library.
+
+## Generate
+
+```sh
+xsdb cpp-json-jsonc.template path/to/schema.xsd            # to stdout
+xsdb --out-dir gen/ cpp-json-jsonc.template path/to/schema.xsd
+```
+
+Output is a single stream with `/* FILE: name */` markers. The header banner
+gives the csplit command to break it into files:
+
+```sh
+xsdb cpp-json-jsonc.template schema.xsd | csplit - '/\/\* FILE: /' '{*}'
+```
+
+For a schema named `foo.xsd` you get three files: `json_common.h` (shared
+`JsonRef` + `json_buffer`), `json_foo.hpp`, and `json_foo.cpp`.
+
+## Toolchain & dependencies
+
+- A C++11 compiler (`-std=c++11`): the code uses `std::unique_ptr`,
+  `std::function`, move semantics, and in-class member initializers.
+- Link **json-c** (`-ljson-c`); the generated `.cpp` includes `<json.h>`.
+- Link **libb64** only when the schema uses `base64Binary`. In that case the
+  `.cpp` pulls in `b64/cencode.h` / `b64/cdecode.h` under an `extern "C"`
+  guard. (`hexBinary` needs no extra library — hex is encoded inline.)
+
+## Generated API
+
+Per schema, the header declares:
+
+- **Element classes** — one `class json_<name>` per complex type. Members are
+  value types (`std::string`, fixed-width ints, `std::vector<...>` for lists,
+  `std::vector<uint8_t>` for binary), default-initialized in-class. Each class
+  has `bool validate() const` and a `virtual ~json_<name>()` so subtypes
+  destroy correctly. Scalar content lands in a `Content_` member; attributes
+  become `<attrName>_` members.
+- **`class Factory`** — one overridable
+  `virtual std::unique_ptr<json_<name>> create_<name>() const` per element.
+  The default returns the generated class; subclass `Factory` and override a
+  `create_*` to inject your own subtype. One virtual covers allocate+construct;
+  the returned `unique_ptr` covers destroy. Same idiom as cpp-xml-expat.
+- **`struct JsonRef`** (in `json_common.h`) — a move-only RAII owner around a
+  `json_object*` that calls `json_object_put` on destruction, so json-c's
+  manual refcounting becomes scope-bound. Copy is deleted; `get()`,
+  `release()`, and `reset()` are provided. No double-put, no leak.
+- **`struct json_marshaller`** — holds the document root (`JsonRef pRoot_`) plus
+  one `unmarshal_<name>` `std::function` callback slot per element; set the
+  slots for the elements you want delivered during unmarshalling.
+- **Marshal API** — `json_marshal(marshaller)` resets the root and returns a
+  `json_marshal_<root>` struct of nested `marshal_<child>` callbacks; call them
+  to attach element objects under their parent. `json_marshal_flush(marshaller,
+  isDocEnd)` serializes the root to a `json_buffer` (`std::string`) via
+  `json_object_to_json_string_ext(..., JSON_C_TO_STRING_PLAIN)`.
+- **Unmarshal API** — `json_unmarshal(marshaller, buf, isDocEnd)` parses `buf`
+  with `json_tokener_parse`, walks matching keys, and fires your callbacks.
+  `json_unmarshal_ex(..., factory)` takes an explicit `Factory` override.
+
+Build and parse go through json-c calls: `json_object_new_object`,
+`json_object_object_add`, `json_object_object_get_ex`, `json_object_get_*`.
+
+**Facet validate()** — `validate()` enforces facets recorded on the schema and
+**throws `std::runtime_error("facet violation")`** on a breach (returning
+`true` otherwise). Numeric ranges become `>=`/`<=` checks, string lengths use
+`.size()`, numeric enumerations compare directly, and string enumerations
+switch on a seed-0 SDBM hash (with a strcmp fallback for hash collisions).
+During unmarshalling `validate()` gates the callback; pattern facets are not
+enforced.
+
+**base64 / hex / list** — `base64Binary` and `hexBinary` map to
+`std::vector<uint8_t>`; base64 routes through libb64, hex is encoded inline. A
+`list` of items maps to `std::vector<...>` and marshals as a JSON array via
+generated `_marshal_list_*` / `_unmarshal_list_*` helpers.
+
+## Example
+
+`rating.xsd`:
+
+```xml
+<schema>
+  <element name="foo">
+    <complexType>
+      <attribute name="attrib1Required" type="string" use="required"/>
+      <attribute name="attrib2Optional" type="integer" default="5"/>
+      <sequence><element name="name" minOccurs="0"/></sequence>
+    </complexType>
+  </element>
+</schema>
+```
+
+```sh
+xsdb cpp-json-jsonc.template foo.xsd | csplit - '/\/\* FILE: /' '{*}'
+```
+
+Generated class + Factory (excerpt):
+
+```cpp
+class json_foo {
+public:
+    uint32_t    eid_ = 0;
+    int64_t     attrib2Optional_ = 0;
+    std::string attrib1Required_;
+    std::string attrib1Optional_;
+    bool validate() const;
+    virtual ~json_foo() {}
+};
+
+class Factory {
+public:
+    virtual ~Factory() {}
+    virtual std::unique_ptr<json_foo> create_foo() const {
+        return std::unique_ptr<json_foo>(new json_foo());
+    }
+    // ... create_name(), etc.
+};
+```
+
+Marshal drive (build a document, attach children, flush):
+
+```cpp
+json_marshaller m;
+json_marshal_foo_xsd doc = json_marshal(m);   // resets m.pRoot_
+
+json_foo foo;
+foo.attrib1Required_ = "hi";
+json_marshal_foo fooFns = doc.marshal_foo(&m, &foo, doc.pSelf);
+
+json_name child;
+child.Content_ = "world";
+fooFns.marshal_name(&m, &child, fooFns.pSelf);
+
+json_buffer out = json_marshal_flush(m, /*isDocEnd=*/true);
+```
+
+Unmarshal drive (parse, receive via callbacks):
+
+```cpp
+json_marshaller m;
+m.unmarshal_foo = [](json_marshaller*, const json_foo* p, uint32_t parent) {
+    use(p->attrib1Required_);          // p->validate() already passed
+};
+json_unmarshal(m, out, /*isDocEnd=*/true);
+```
+
+Subclass `Factory` and pass it to `json_unmarshal_ex` to allocate your own
+subtypes; the `JsonRef`/`unique_ptr` RAII handles all freeing.
+
+## Notes
+
+- **JSON shape** — each element is a JSON object keyed by element name; nested
+  elements are nested objects. Attributes are plain keys; simple **content** is
+  stored under the reserved key `"$"`. There is no XML-style attribute/element
+  namespace distinction, so an attribute and a child element with the same name
+  would collide in the JSON.
+- `eid_` is an internal id used to thread parent/child relationships; it is not
+  part of the serialized JSON.
+- `isDocEnd` controls whether the root `JsonRef` is reset after a
+  flush/unmarshal; pass `true` for a complete single document.

--- a/docs/templates/cpp-xml-expat.md
+++ b/docs/templates/cpp-xml-expat.md
@@ -1,0 +1,188 @@
+# cpp-xml-expat
+
+Modern C++11 XML marshalling bindings (expat-driven SAX parse), one element
+class per XSD element with an overridable factory and per-element hooks.
+
+## Generate
+
+```sh
+xsdb cpp-xml-expat <schema.xsd>            # to stdout (FILE markers)
+xsdb --out-dir <dir> cpp-xml-expat <schema.xsd>
+```
+
+`--out-dir` splits the output into three files (the multi-file stream is
+delimited by `/* FILE: ... */` markers, splittable with the emitted
+`csplit` command):
+
+- `xml_common.h` — shared includes (`<cstdint>`, `<string>`, `<vector>`,
+  `<memory>`, `<stdexcept>`).
+- `xml_<schema>.hpp` — `namespace xml` public API: `Element`, the element
+  classes, `Factory`, `Marshaller`.
+- `xml_<schema>.cpp` — implementation (validators, marshal/unmarshal,
+  expat thunks).
+
+`<schema>` is the schema's root element name with any trailing `_xsd`
+stripped.
+
+## Toolchain & dependencies
+
+- A C++11 compiler — compile with `-std=c++11`.
+- Link **expat** (`#include <expat.h>`); the bindings call
+  `XML_ParserCreateNS`, so namespace-aware expat is required.
+- Link **libb64** *only when* the schema uses `xs:base64Binary` — its C
+  headers (`b64/cencode.h`, `b64/cdecode.h`) are pulled in under
+  `extern "C"`. `xs:hexBinary` needs no extra library (hex codec is
+  emitted inline). No-binary schemas link neither.
+
+Round-trip harness (`test/roundtrip_util.cpp`, `cppXmlRoundtrip` /
+`ccRoundtripImpl`): generates the `cpp-xml-expat` binding plus the
+`cpp-xml-expat-test` driver, splits the FILE-marked output, then compiles
+`<base>-bin.cpp` + `xml_<base>.cpp` + the libb64 archive against the
+expat include/link flags with the project C++ compiler at `-std=c++11`,
+and runs the self-checking binary.
+
+## Generated API
+
+All in `namespace xml`. Modern C++11 throughout: `std::string` /
+fixed-width `int*_t` / `std::vector` members, RAII, no manual `free`.
+
+- **`class Element`** — abstract base. Pure virtual `setContent`,
+  `setAttribute`; virtual `validate()` (default no-op). Lets the parse
+  stack hold heterogeneous elements as `unique_ptr<Element>` without a
+  union or type switch.
+
+- **Element classes** — one `class <name> : public Element` per element.
+  Members are default-initialised (`= {}`): scalar content as `content_`,
+  each attribute as `<attr>_`. Type mapping (`cpp_type_info`): string-like
+  XSD types → `std::string`, `xs:boolean` → `bool`, integers → narrowest
+  fixed-width `int*_t`/`uint*_t` for a known facet range, `xs:decimal` →
+  `long double`, `xs:base64Binary`/`xs:hexBinary` →
+  `std::vector<uint8_t>`, `xs:list` → `std::vector<T>` (space-separated).
+  `setContent`/`setAttribute` parse text into the typed members.
+
+- **`class Factory`** — overridable. One
+  `virtual std::unique_ptr<<name>> create_<name>() const` per element,
+  returning the generated class by default. Subclass and override a
+  `create_*` to inject a derived element subtype into the parse.
+
+- **`class Marshaller`** — constructed with an optional `const Factory*`
+  (null → an internal default factory).
+  - Marshal: `marshalBegin()` writes the XML prolog, `marshal_<name>(const
+    <name>&)` appends each element (it first closes open tags down to the
+    element's parent so nesting is correct), `flush(bool isDocEnd)` closes
+    any still-open tags and returns + clears the accumulated text.
+  - Unmarshal: `unmarshal(const char* data, size_t len, bool isDocEnd)`
+    feeds a (possibly partial) chunk to expat; the overridable
+    `virtual void on_<name>(const <name>&)` hook fires as each element
+    closes.
+
+- **expat C-ABI bridge (load-bearing).** Member function pointers can't
+  cross expat's C ABI, so `unmarshal` registers `static XMLCALL`
+  thunks (`startThunk_`/`endThunk_`/`charsThunk_`) that recover `this`
+  from `XML_GetUserData` and forward to the `onStart`/`onEnd`/`onChars`
+  members. A C++ exception must **not** unwind through expat's C frames:
+  each thunk catches, stashes the exception in `pending_`
+  (`std::exception_ptr`), and calls `XML_StopParser`; `unmarshal`
+  rethrows it once control is back in C++. `localName_` strips expat's
+  `uri:local` NS expansion to the local name for dispatch.
+
+- **Facet validation.** Each element's `validate()` (out-of-line in the
+  `.cpp`) checks range/length/enum facets and throws `std::runtime_error`
+  on a miss. `onEnd` calls `validate()` before the `on_<name>` hook, so a
+  violation surfaces (via the thunk → `pending_` path) as a thrown
+  exception out of `unmarshal`. With no facets, `validate()` is empty.
+
+- **Namespaces.** A `targetNamespace` is emitted as an `xmlns:tns="..."`
+  declaration on the document-root start tag; qualified element/attribute
+  tags are prefixed `tns:`. Parsing uses namespace-aware expat and matches
+  on local names, so prefixes round-trip. Non-namespaced schemas emit no
+  NS at all.
+
+## Example
+
+```xml
+<!-- record.xsd -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:phase0"
+           targetNamespace="urn:example:phase0">
+  <xs:element name="record" type="tns:RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="count" type="xs:integer"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>
+```
+
+```sh
+xsdb --out-dir gen cpp-xml-expat record.xsd
+# -> gen/xml_common.h, gen/xml_record.hpp, gen/xml_record.cpp
+```
+
+Generated class, factory entry, and the namespaced start tag (abridged):
+
+```cpp
+class record : public xml::Element {
+public:
+    std::string id_ = {};
+    void setAttribute(const std::string& name,
+                      const std::string& value) override {
+        if (name == "id") { id_ = value; }
+        else (void)value;
+    }
+    // ...
+};
+
+// in xml::Factory
+virtual std::unique_ptr<record> create_record() const {
+    return std::unique_ptr<record>(new record());
+}
+
+// in Marshaller::marshal_record
+out_ += "<tns:record xmlns:tns=\"urn:example:phase0\"";
+out_ += " id=\""; out_ += obj.id_; out_ += "\"";
+```
+
+Drive marshal then round-trip back via a hook:
+
+```cpp
+#include "xml_record.hpp"
+using namespace xml;
+
+struct Sink : Marshaller {
+    void on_record(const record& r) override { /* got it */ }
+};
+
+Sink m;
+record r; r.id_ = "r1";
+m.marshalBegin();
+m.marshal_record(r);
+std::string doc = m.flush(true);          // complete XML text
+
+m.unmarshal(doc.data(), doc.size(), true); // fires on_record(...)
+```
+
+To inject a subtype, subclass `Factory`, override `create_record()` to
+return your derived type, and pass `&factory` to the `Marshaller`
+constructor.
+
+## Notes
+
+- Marshalling is **caller-ordered**: you must call `marshal_*` parent
+  before child (matching the schema's nesting); `marshal_*` only closes
+  tags down to the element's parent, it does not reorder. `flush(true)`
+  closes whatever remains open.
+- `validate()` (and thus facet enforcement) runs on **unmarshal**, not on
+  marshal — building an out-of-range object and marshalling it does not
+  throw.
+- Facet messages are intentionally terse (`throw std::runtime_error(
+  "facet")` / `"mismatch"`); they identify a violation, not which field.
+- Integer parsing goes through `std::stol`/`std::stoll`/`std::stoul`/
+  `std::stoull` and is cast to the narrowed width — out-of-range text
+  throws `std::out_of_range` from the standard library, surfaced through
+  the same `unmarshal` rethrow path.
+- One `xml` namespace and one `Element`/`Factory`/`Marshaller` triple per
+  schema; generating two schemas into the same compilation unit would
+  collide.

--- a/docs/templates/java-json.md
+++ b/docs/templates/java-json.md
@@ -1,0 +1,188 @@
+# java-json
+
+Generates Java marshalling/unmarshalling code that maps an XSD schema onto JSON
+using the `org.json` library (`JSONObject` / `JSONArray`). Marshal builds a
+`JSONObject`; unmarshal consumes one. Binary content is base64/hex-encoded via
+Apache Commons Codec.
+
+## Generate
+
+```sh
+# print all files to stdout (separated by /* FILE: name */ markers)
+xsdb java-json.org.tmpl schema.xsd
+
+# split the marked output into real files under build/
+xsdb --out-dir build java-json.org.tmpl schema.xsd
+```
+
+The output package defaults to `com.mobitv.generated.json`; override with
+`-package <name>`. (`-h` prints the template's own argument help.)
+
+## Toolchain & dependencies
+
+- **JDK.** The test harness builds at `source`/`target` 1.8; CI runs Temurin
+  JDK 21. Java 11+ is fine.
+- **`org.json`** — the JSON model. Maven coordinates:
+  `org.json:json:20231013`.
+- **`org.apache.commons.codec`** — base64/hex encoding. Maven coordinates
+  `org.apache.directory.studio:org.apache.commons.codec:1.8` in the test pom
+  (the package provides `org.apache.commons.codec.binary.Base64` and `Hex`).
+  Note this target uses Commons Codec, **not** `java.util.Base64`.
+
+## Generated API
+
+The template always emits three scaffold classes plus one class per complex
+type:
+
+- **`Marshalable.java`** — interface with `JSONObject marshal()`.
+- **`JSONObjectAdapter.java`** — thin wrapper over `JSONObject` with typed
+  `getString`/`getLong`/`getObject`/`getList`/`has` and overloaded `put`. Only
+  the accessor/`put` overloads the schema actually needs are emitted.
+- **`JSONArrayAdapter.java`** — wrapper over `JSONArray` with `length()`, `put`,
+  and (when the schema uses binary lists) `getBase64`/`getHex` /
+  `putBase64`/`putHex`.
+- **`<Type>.java`** — one per complex type. Private `_`-prefixed fields,
+  getters/`set*` setters, a `marshal()`, a `validate()`, and three constructors:
+  a default one, `T(JSONObject)`, and `T(JSONObjectAdapter)` (the latter does
+  the real unmarshal).
+
+### Marshal / unmarshal
+
+- **Unmarshal** is the `T(JSONObjectAdapter)` constructor: each field is read by
+  key, optional fields guarded by `jObj.has(key)` (absent → declared default, or
+  `null`), then `validate()` runs at the end. Attributes are keyed with a `@`
+  prefix (`@attrib1Required`); simple-content text uses the key `$`.
+- **Marshal** builds a fresh `JSONObjectAdapter` and `put`s each present field.
+  Optional `String` fields are emitted only when non-null and non-empty;
+  optional boxed numerics only when non-null.
+- **Nested complex types** are unmarshalled by direct construction:
+  `_item = new Item(jObj.getObject("item"))`, and marshalled via
+  `_item.marshal()`. (There is no overridable factory layer in this target.)
+
+### Facet validation
+
+When a field carries restriction facets, `validate()` enforces them after
+unmarshal and throws `IllegalArgumentException` on violation:
+
+- `minInclusive`/`maxInclusive` → range check
+  (`if (_v != null && !(lo <= _v && _v <= hi)) throw ...`).
+- `length`/`minLength`/`maxLength` → string length check.
+- `enumeration` → a shared `private static final Set<String>` is emitted and
+  checked with `.contains(_v)` for strings.
+
+**Pattern facets are not enforced.** Marshalling does not validate.
+
+### Smallest-type narrowing
+
+For an `integer`/`long` field whose facets bound it to a known int range, the
+member, accessors, and unmarshal call narrow to the smallest signed boxed type
+that holds the range (`Byte`/`Short`/`Integer`/`Long`). Java has no unsigned
+types, so e.g. `0..255` widens to `Short`. `Byte`/`Short` read via
+`(byte) jObj.getInt(...)` / `(short) jObj.getInt(...)` and marshal via
+`.intValue()` (those two lack dedicated adapter methods).
+
+### base64 / hex / list
+
+XSD `list` types map to `List`-backed fields. `base64Binary` items decode with
+`Base64.decodeBase64` and encode with `Base64.encodeBase64String`; `hexBinary`
+items decode with `Hex.decodeHex` and encode with `Hex.encodeHexString` (which
+can throw `DecoderException`, so unmarshal constructors are declared
+`throws JSONException, DecoderException`). A binary field's Java type is
+`List<byte []>`.
+
+## Example
+
+`order.xsd`:
+
+```xml
+<schema>
+  <element name="order">
+    <complexType>
+      <sequence>
+        <element name="qty">
+          <simpleType>
+            <restriction base="int">
+              <minInclusive value="1"/>
+              <maxInclusive value="100"/>
+            </restriction>
+          </simpleType>
+        </element>
+        <element name="item">
+          <complexType>
+            <attribute name="sku" type="string" use="required"/>
+          </complexType>
+        </element>
+      </sequence>
+    </complexType>
+  </element>
+</schema>
+```
+
+```sh
+xsdb --out-dir build java-json.org.tmpl order.xsd
+```
+
+`qty` narrows to `Byte` (range 1..100) and gets a range check; `item` becomes a
+nested `Item` class:
+
+```java
+public class Order implements Marshalable {
+	private Byte _qty;
+	private Item _item = null;
+
+	public Order(JSONObjectAdapter jObj)
+			throws JSONException, DecoderException {
+		if (!jObj.has("qty")) _qty = null;
+		else                  _qty = (byte) jObj.getInt("qty");
+		if (!jObj.has("item")) _item = null;
+		else                   _item = new Item(jObj.getObject("item"));
+		validate();
+	}
+
+	public void validate() {
+		if (_qty != null && !(1 <= _qty && _qty <= 100))
+			throw new IllegalArgumentException("qty: out of range");
+	}
+
+	public JSONObject marshal() throws JSONException {
+		JSONObjectAdapter retObj =
+			new JSONObjectAdapter(new JSONObject());
+		if (null != _qty) retObj.put("qty", _qty.intValue());
+		if (null != _item) retObj.put("item", _item.marshal());
+		return retObj.getJSONObject();
+	}
+}
+```
+
+Driving marshal then unmarshal:
+
+```java
+Order o = new Order();
+o.setQty((byte) 5);
+
+JSONObject json = o.marshal();         // {"qty":5}
+Order back = new Order(json);          // re-validates qty range
+```
+
+## Notes
+
+- **Attribute keys carry a `@` prefix and simple-content text uses `$`** in the
+  JSON object — chosen so attributes and element content can coexist as distinct
+  keys.
+- **Adapter methods are emitted on demand** — `JSONObjectAdapter` /
+  `JSONArrayAdapter` only get the getters/`put` overloads the schema uses, so two
+  schemas can produce different adapter classes.
+- **The base64/hex decoders may throw `DecoderException`**, which propagates out
+  of the unmarshal constructors (declared `throws JSONException,
+  DecoderException`).
+- **Pattern facets are not enforced**, and the `LuaProcessor` collapses
+  restrictions to their base, so only the facet kinds listed above validate.
+- **Facet violations throw `IllegalArgumentException`** from `validate()` on the
+  unmarshal path; marshalling does not validate.
+- **There is no factory/subtype-injection layer** in this target — nested types
+  are constructed directly. (The `java-xml-stax` target is the one with an
+  overridable `Factory`.)
+- Adding a new output target is template-only — no C++ change. This target lives
+  in `templates/java-json.org.tmpl` plus the subtemplates under
+  `templates/java-json.org/`.
+```

--- a/docs/templates/java-xml-stax.md
+++ b/docs/templates/java-xml-stax.md
@@ -1,0 +1,177 @@
+# java-xml-stax
+
+Generates Java marshalling/unmarshalling code that maps an XSD schema onto XML
+using the JDK's built-in StAX API (`javax.xml.stream`). No external XML
+dependency — marshal goes through `XMLStreamWriter`, unmarshal through a pull
+loop over `XMLStreamReader`.
+
+## Generate
+
+```sh
+# print all files to stdout (separated by /* FILE: name */ markers)
+xsdb java-xml-stax.tmpl schema.xsd
+
+# split the marked output into real files under build/
+xsdb --out-dir build java-xml-stax.tmpl schema.xsd
+```
+
+The output package defaults to `com.mobitv.app`; override with
+`-package <name>`. (`-h` prints the template's own argument help.)
+
+## Toolchain & dependencies
+
+- **JDK only.** StAX (`XMLStreamWriter` / `XMLStreamReader` /
+  `XMLInputFactory` / `XMLOutputFactory`) is part of the standard library, so
+  the generated code compiles and runs against a bare JDK — no XML library on
+  the classpath. The test harness builds at `source`/`target` 1.8.
+- **`java.util.Base64`** — used (fully qualified) only when the schema has a
+  `base64Binary` content/attribute.
+- A `Hex.java` helper class is emitted only when the schema uses `hexBinary`.
+
+## Generated API
+
+For a schema, the template always emits four scaffold classes plus one class
+per complex type:
+
+- **`Element.java`** — abstract base. Holds a text `StringBuilder _buf`, a lazy
+  `List<Element> _children`, and a `Factory _factory`. `marshal(XMLStreamWriter)`
+  writes the start element (namespaced or not), then namespaces, attributes,
+  content, recurses into children, and writes the end element.
+  `unmarshal(XMLStreamReader)` is the StAX pull loop: on `START_ELEMENT` it
+  creates a child via the factory by local name and recurses; `CHARACTERS`/`CDATA`
+  append to `_buf`; `END_ELEMENT` calls `readContent()` then `validate()`.
+  Subclasses override only the hooks that differ (`localName`, `namespaceURI`,
+  `marshalNamespaces`, `marshal/readAttributes`, `marshal/readContent`,
+  `validate`).
+- **`Factory.java`** — overridable factory. Has one `protected create<Type>()`
+  per non-root type and a `create(String localName)` dispatcher. Subclass and
+  override a `create<Type>()` to inject a custom subtype into unmarshalling.
+- **`Document.java`** — document entry points. `String marshal(Element root)`
+  serializes to a string via `XMLOutputFactory`; `Element unmarshal(String xml)`
+  reads via `XMLInputFactory`, creating the root through the (overridable)
+  factory. Construct with `new Document()` or `new Document(Factory)`.
+- **`<Type>.java`** — one per complex type. Private attribute fields, an
+  optional `_text` content field, a constructor that applies attribute
+  defaults, getters/`set_*` setters, and the overridden marshal/unmarshal/
+  validate hooks.
+
+### Marshal / unmarshal
+
+Marshal is pure StAX: `w.writeStartElement(...)`, `w.writeAttribute(...)`,
+`w.writeCharacters(...)`. Unmarshal dispatches children by **URI-less local
+name** (`r.getLocalName()`); attributes are read by local name in a
+`getAttributeCount()` loop. Numeric content/attributes parse with
+`Long.parseLong(... .trim())` (or the narrowed type's parser, below).
+
+### Facet validation
+
+When a content/attribute carries restriction facets, the type's `validate()`
+override runs after unmarshal. Each value's checks are scoped in their own block
+(local `_v`); a violation throws `IllegalArgumentException` (unlike the C target,
+which silently drops). `minInclusive`/`maxInclusive` → range check;
+`length`/`min`/`maxLength` → `String.valueOf(_v).length()` check;
+`enumeration` → numeric `_v == ...` comparisons for boxed-numeric types, or a
+shared static `HashSet<String>.contains(_v)` for strings. **Pattern facets are
+not enforced.**
+
+### Smallest-type narrowing
+
+For an `integer`/`long` field whose facets bound it to a known int range, the
+member, accessors, and parse call narrow to the smallest signed boxed type that
+holds the range (`Byte`/`Short`/`Integer`/`Long`). Java has no unsigned types,
+so e.g. `0..255` widens to `Short`.
+
+### Namespaces
+
+When the schema has a `targetNamespace`, qualified elements override
+`namespaceURI()` to return the URI, so `marshal` emits a namespaced start tag.
+The single document-root element also overrides `marshalNamespaces()` to
+`w.writeNamespace("tns", <uri>)`, and `Document.marshal` calls
+`w.setPrefix("tns", <uri>)` before writing the root — binding a synthesized
+`tns:` prefix (the original XSD source prefix is not in the model). Local
+elements/attributes are qualified only when their XSD `form` is qualified.
+**Unmarshal matches on bare local names**, ignoring the URI. A non-namespaced
+schema emits byte-identical output to the pre-namespace template (no
+`namespaceURI`/`marshalNamespaces`/`setPrefix`).
+
+### base64 / hex / list
+
+`base64Binary` marshals via `java.util.Base64.getEncoder()`/`getDecoder()`;
+`hexBinary` via the emitted `Hex` helper. XSD `list` types map to Java
+`List`-backed fields (string/int/long/bool/float/base64/hex variants).
+
+## Example
+
+`record.xsd`:
+
+```xml
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:phase0"
+           targetNamespace="urn:example:phase0">
+  <xs:element name="record" type="tns:RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="count" type="xs:integer"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>
+```
+
+```sh
+xsdb --out-dir build java-xml-stax.tmpl record.xsd
+```
+
+The root type (`record`, sanitized to `record_` since it collides with no Java
+keyword but is reserved here) emits the namespace overrides:
+
+```java
+public class record_ extends Element {
+	private String _id;
+
+	@Override public String localName() { return "record"; }
+
+	@Override protected String namespaceURI() { return "urn:example:phase0"; }
+
+	@Override protected void marshalNamespaces(XMLStreamWriter w)
+			throws XMLStreamException {
+		w.writeNamespace("tns", "urn:example:phase0");
+	}
+
+	@Override protected void marshalAttributes(XMLStreamWriter w)
+			throws XMLStreamException {
+		if (_id != null) w.writeAttribute("id", _id);
+	}
+	// ... readAttributes, getters/setters ...
+}
+```
+
+Driving marshal then unmarshal:
+
+```java
+record_ r = new record_();
+r.set_id("r1");
+
+Document doc = new Document();
+String xml = doc.marshal(r);   // <tns:record xmlns:tns="urn:example:phase0" id="r1"/>
+Element back = doc.unmarshal(xml);  // matched by local name "record"
+```
+
+## Notes
+
+- **Type names are sanitized for Java**, which can rename a class relative to
+  the XSD element (`record` → `record_` above). `localName()` still returns the
+  original XSD name, so on-the-wire element names are unaffected.
+- **Unmarshal ignores namespace URIs** — it dispatches purely on local name, so
+  same-local-name elements from different namespaces are not distinguished.
+- **A single `tns:` prefix is synthesized** for the one target namespace; the
+  original source prefix from the XSD is not carried in the model.
+- **Pattern facets are not enforced**, and the `LuaProcessor` collapses
+  restrictions to their base, so only the facet kinds listed above validate.
+- **Facet violations throw `IllegalArgumentException`** from `validate()` on the
+  unmarshal path; marshalling does not validate.
+- Adding a new output target is template-only — no C++ change. This target lives
+  in `templates/java-xml-stax.tmpl` plus the per-type subtemplates under
+  `templates/java-xml-stax/`.
+```

--- a/docs/templates/python-json.md
+++ b/docs/templates/python-json.md
@@ -1,0 +1,126 @@
+# python-json
+
+Generates a Python module that marshals/unmarshals XSD-described data to and
+from JSON using only the standard-library `json` module. No external
+dependencies.
+
+## Generate
+
+```sh
+xsdb python-json.tmpl <schema.xsd>
+```
+
+The output is a single Python source file written to stdout.
+
+## Toolchain & dependencies
+
+- **python3** only. The generated code imports `json` (always), plus `base64`
+  and/or `binascii` when the schema uses `base64Binary` / `hexBinary` types.
+  Nothing outside the standard library is required.
+
+## Generated API
+
+For each element the generator emits a `json_<name>` class deriving from
+`_jsonelement`, plus one root class `json_<schemaName>`.
+
+- **Element classes** (`json_<name>`) hold attributes as `self._<attr>` fields
+  and child content in `self._content`. Each attribute gets a getter
+  `<attr>(self)` and a setter `set_<attr>(self, value)`. Attribute `default`
+  values from the XSD are seeded in `__init__`.
+- **marshal()** builds a dict
+  `{"name": <name>, "attrs": {...}, "content": <content>}` and returns it.
+  Attributes are typed-coerced (e.g. `int(self._attrib)`). For complex content,
+  `content` is a list of child element dicts (each child's `marshal()`); for
+  simple content it is the typed scalar/list.
+- **unmarshal(obj)** reads the dict back, coercing attribute and content values
+  to their Python types and reconstructing children.
+- **Root class** `json_<schemaName>`: `marshal()` returns
+  `json.dumps([...])` over its top-level children (the only place JSON text is
+  produced); `unmarshal(obj)` consumes the parsed list. So marshal yields a JSON
+  string and unmarshal takes already-parsed Python objects — pair the root's
+  `marshal()` with `json.loads` on the consumer side.
+- **Overridable factory registry.** A module-level `factories` dict maps each
+  element name to its class. Every unmarshal path constructs children via
+  `factories[name]()`, so assigning `factories['foo'] = MySubclass` injects a
+  subclass without touching generated code.
+- **Facet validation.** When an element or attribute carries facets, the class
+  gains a `validate()` method (called at the end of `unmarshal`). It raises
+  `ValueError` on violations: `range` (min/maxInclusive), `length`
+  (length/min/maxLength, measured on `len(str(_v))`), and `enumeration`
+  (numeric enums compare against a module-level `_ENUM_*` frozenset; string
+  enums compare stringified). Pattern facets are not enforced.
+- **Binary & list handling.** `base64Binary` marshals via
+  `base64.b64encode(...).decode('utf-8')` and unmarshals via `b64decode`;
+  `hexBinary` uses `binascii.hexlify(...).decode('utf-8')` / `bytes.fromhex`.
+  XSD `list` item types map to per-element list comprehensions of the
+  corresponding scalar coercion.
+
+## Example
+
+```xsd
+<!-- rating.xsd: integer 1..5 -->
+<schema>
+  <element name="rating" type="ratingType" />
+  <simpleType name="ratingType">
+    <restriction base="integer">
+      <minInclusive value="1"/>
+      <maxInclusive value="5"/>
+    </restriction>
+  </simpleType>
+</schema>
+```
+
+```sh
+xsdb python-json.tmpl rating.xsd > rating.py
+```
+
+Generated (abridged):
+
+```python
+class json_rating(_jsonelement):
+    def marshal(self):
+        attrs = {}
+        content = self._content[0]
+        return {"name": "rating", "attrs": attrs, "content": content}
+
+    def unmarshal(self, obj):
+        content = obj["content"]
+        self._content = [int(content)]
+        self.validate()
+
+    def validate(self):
+        _v = self._content[0] if self._content else None
+        if _v is not None and not (1 <= _v <= 5):
+            raise ValueError("content: out of range")
+```
+
+Round-trip:
+
+```python
+import json, rating
+
+r = rating.json_rating()
+r.set_... # populate via setters / _content as appropriate
+
+doc = rating.json_rating_xsd()
+doc.getContent().append(r)
+text = doc.marshal()            # -> JSON string (json.dumps inside)
+
+doc2 = rating.json_rating_xsd()
+doc2.unmarshal(json.loads(text))  # validate() runs; bad values raise ValueError
+```
+
+## Notes
+
+- **JSON has no attribute/element distinction.** Each element is represented as
+  a dict with explicit `"attrs"` and `"content"` keys: XSD attributes go into
+  the `"attrs"` sub-dict (keyed by attribute name), child elements go into the
+  `"content"` list as nested element dicts, and simple-content values go
+  directly into `"content"` as the typed scalar or list. The element's own name
+  is carried in the `"name"` key, which is how the factory registry picks the
+  class on unmarshal.
+- Only the **root** class emits/consumes JSON text (`json.dumps`). Inner element
+  classes work in plain Python dicts; feed the root's output through
+  `json.loads` before calling its `unmarshal`.
+- Facet validation runs only on `unmarshal`, not on `marshal` or via setters.
+  Pattern facets are accepted by the parser but not enforced in generated code.

--- a/docs/templates/python-sax.md
+++ b/docs/templates/python-sax.md
@@ -1,0 +1,157 @@
+# python-sax
+
+Generates a self-contained Python module that marshals/unmarshals XML using
+only the standard library `xml.sax` parser — no external dependencies.
+
+## Generate
+
+```sh
+xsdb python-sax <schema.xsd>
+```
+
+Emits a single Python module to **stdout**; redirect it to a `.py` file.
+
+## Toolchain & dependencies
+
+Just **python3**. The generated module imports only `xml.sax` from the standard
+library. `import base64` / `import binascii` are added on demand, but only when
+the schema actually uses `base64Binary` / `hexBinary` types.
+
+## Generated API
+
+The module is a flat set of classes plus a SAX handler.
+
+- **`_xmlelement`** — base class for every element. Holds an ordered
+  `_content` list (mixed child `_xmlelement`s and text strings); `getContent()`
+  returns it.
+- **`xml_<element>`** — one class per element/type in the schema, derived from
+  `_xmlelement`. Provides:
+  - `marshal(self, stream)` — writes the element's XML to a writable stream.
+  - `unmarshal(self, attributes, content)` — populates the instance from a SAX
+    attribute dict and a content list.
+  - per-attribute getter `attr()` / setter `set_attr(value)`; attribute
+    defaults are set in `__init__`.
+- **`_handler(xml.sax.ContentHandler)`** — the SAX content handler. It drives
+  parsing with **namespace-aware** callbacks (`startElementNS` / `endElementNS`),
+  maintaining an element stack and building the tree bottom-up by calling each
+  element's `unmarshal`.
+- **`xml_<schema>_xsd(_handler, _xmlelement)`** — the document root class,
+  combining the handler and an element. This is the entry point:
+  - `marshal(self, stream)` — writes the XML declaration then marshals each
+    top-level element.
+  - `unmarshal(self, stream)` — builds a parser, enables
+    `feature_namespaces`, parses `stream`, and stores the result in
+    `_content`.
+
+### Overridable element factory
+
+The handler maps each element's **local name** to a constructor via the
+`self._elemTbl` dict, built in `_handler.__init__`:
+
+```python
+self._elemTbl = {
+    'foo': lambda: xml_foo(),
+    'name': lambda: xml_name(),
+}
+```
+
+`startElementNS` looks up `self._elemTbl[name[1]]()` (where `name` is the
+`(uri, localname)` pair). To inject a subtype, subclass the document root and
+reassign an entry in `_elemTbl` after the base `__init__`.
+
+### Facet validation
+
+When an element's content or an attribute carries XSD facets, the class gets a
+`validate()` method that `unmarshal` calls automatically. Checks raise
+`ValueError` on violation. Supported facet kinds: numeric **range**
+(`minInclusive`/`maxInclusive`), **length** (`length`/`minLength`/`maxLength`),
+and **enumeration** (membership against a module-level `frozenset`). Pattern
+facets are not enforced.
+
+```python
+def validate(self):
+    _v = self._content[0] if self._content else None
+    if _v is not None and not (1 <= _v <= 5):
+        raise ValueError("content: out of range")
+```
+
+### Namespaces
+
+If the schema has a target namespace, the document-root element emits an
+`xmlns` (or `xmlns:<prefix>`) declaration on its open tag during marshalling;
+qualified elements are written with a synthesized prefix (`ns`, or `ns1`, `ns2`
+… for multiple URIs). Because parsing uses `feature_namespaces`, elements are
+matched by **(uri, localname)**, so the wire prefix is irrelevant on input.
+
+## Example
+
+`record.xsd`:
+
+```xml
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:phase0"
+           targetNamespace="urn:example:phase0">
+  <xs:element name="record" type="tns:RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="count" type="xs:integer"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>
+```
+
+Generate:
+
+```sh
+xsdb python-sax record.xsd > record.py
+```
+
+A generated class (note the root-level `xmlns` and the `id` attribute):
+
+```python
+class xml_record(_xmlelement):
+    def __init__(self):
+        _xmlelement.__init__(self)
+        self._id = None
+
+    def marshal(self, stream):
+        stream.write('<record xmlns="urn:example:phase0"')
+        stream.write(' id="' + str(self._id) + '"')
+        stream.write('>')
+        for node in filter(lambda x: isinstance(x, _xmlelement), self.getContent()):
+            node.marshal(stream)
+        stream.write('</record>')
+
+    def unmarshal(self, attributes, content):
+        if "id" in attributes:
+            self._id = attributes["id"]
+        self._content = content
+```
+
+Use it:
+
+```python
+import sys
+from record import xml_record_xsd
+
+# unmarshal from a file
+doc = xml_record_xsd()
+with open('in.xml') as f:
+    doc.unmarshal(f)
+
+# inspect / mutate the tree via getContent(), then marshal back out
+doc.marshal(sys.stdout)
+```
+
+## Notes
+
+- `unmarshal` takes a **stream**, not a string; wrap text in `io.StringIO`.
+- The element tree is the mixed `getContent()` list (child elements and text);
+  there are no typed child accessors — walk `getContent()` and check
+  `isinstance(node, _xmlelement)`.
+- The handler's `startDocument` seeds the stack with a fixed placeholder tuple;
+  the real root content is collected from the stack after parsing.
+- Pattern facets are accepted by the schema but not validated.
+- Marshalling does no validation; `validate()` runs only on `unmarshal`.

--- a/docs/templates/ts-xml.md
+++ b/docs/templates/ts-xml.md
@@ -1,0 +1,144 @@
+# ts-xml
+
+Generates strict TypeScript that marshals/unmarshals XML using
+**fast-xml-parser**. One module per type, plus a small runtime base and an
+overridable factory.
+
+## Generate
+
+```sh
+xsdb --out-dir <dir> ts-xml.tmpl <schema.xsd>
+```
+
+Output is multi-file: the template emits `/* FILE: ... */` markers and
+`--out-dir` splits them into `Element.ts`, `Factory.ts`, `Document.ts`,
+`index.ts`, and one `<Type>.ts` per element/type. (Without `--out-dir` the
+combined stream goes to stdout with a leading `csplit` recipe.)
+
+## Toolchain & dependencies
+
+- **node** + **typescript** — compiles under `tsc --strict`.
+- **fast-xml-parser** — `XMLParser` / `XMLBuilder` for parse and serialize.
+
+The harness pins these in `test/ts-xml/package.json` (fast-xml-parser 4.4.1,
+typescript 5.4.5). `test/ts-xml/tsconfig.json` targets **ES2019** — the oldest
+target the generated code supports — with `strict: true` and CommonJS modules.
+
+## Generated API
+
+- **`<Type>.ts`** — one `class <Type> extends Element` per type. Attributes and
+  leaf text are optional strict fields (`_attr?: T`, `_text?: T`); attribute
+  defaults are assigned in the constructor. Methods: `localName()`,
+  `marshalAttributes()` / `readAttributes()`, `marshalText()` / `readText()`
+  for leaves, and `validate()`.
+- **`Element.ts`** — abstract base. Holds ordered `children` and a `factory`
+  reference, and converts to/from the fast-xml-parser `preserveOrder` node shape
+  (`toNode()` / `readNode()`). `FxpNode` is the node type; `ATTR_PREFIX` is
+  `"@_"`, `TEXT_KEY` is `"#text"`.
+- **`Factory.ts`** — the overridable `Factory`. `create(localName)` dispatches a
+  tag to a per-type `create<Type>()` (e.g. `createrecord()`). Subclass and
+  override a `create<Type>()` to inject a custom subtype; `unmarshal` routes all
+  element construction through it.
+- **`Document.ts`** — `Document` wraps an `XMLParser`/`XMLBuilder` pair with
+  shared `FXP_OPTIONS` (`preserveOrder`, symmetric attribute prefix,
+  `trimValues: false`, `suppressEmptyNode`) so marshal -> parse -> marshal is
+  byte-stable. `marshal(root)` / `unmarshal(xml)` are the entry points.
+- **`index.ts`** — re-exports everything.
+
+Feature mapping:
+
+- **Facet validate()** — range / length / enumeration facets emit guards that
+  `throw new Error(...)` on violation; `readNode` calls `validate()` after a
+  node is populated. Enumerations hoist a module-level `ReadonlySet`. Pattern
+  facets are not enforced.
+- **Namespace** — when the schema has a `targetNamespace`, the document-root
+  class declares `xmlns:tns` in `marshalAttributes()` and reports its
+  `namespaceURI()`; locals are qualified only when their XSD form is.
+- **base64 / hex** — `base64Binary` and `hexBinary` map to `Uint8Array`.
+- **Lists** — XSD list types map to typed arrays (`number[]`, `string[]`,
+  `boolean[]`).
+
+## Example
+
+```xml
+<!-- nsTargetPrefixed.xsd -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:example:phase0"
+           targetNamespace="urn:example:phase0">
+  <xs:element name="record" type="tns:RecordType"/>
+  <xs:complexType name="RecordType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="count" type="xs:integer"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>
+```
+
+```sh
+xsdb --out-dir ./out ts-xml.tmpl nsTargetPrefixed.xsd
+```
+
+Generated `record.ts` (root, qualified in the target namespace):
+
+```ts
+import { Element } from "./Element";
+
+export class record extends Element {
+	_id?: string;
+
+	constructor() { super(); }
+
+	localName(): string { return "record"; }
+	namespaceURI(): string | undefined { return "urn:example:phase0"; }
+
+	protected marshalAttributes(): Record<string, string> {
+		const a: Record<string, string> = {};
+		a["xmlns:tns"] = "urn:example:phase0";
+		if (this._id !== undefined) a["id"] = this._id;
+		return a;
+	}
+	protected readAttributes(attrs: Record<string, string>): void {
+		if ("id" in attrs) this._id = attrs["id"];
+	}
+}
+```
+
+`Factory.ts` (override a `create<Type>()` to swap in a subtype):
+
+```ts
+export class Factory {
+	protected createrecord(): record { return new record(); }
+	// ...createlabel(), createcount()...
+	create(localName: string): Element | undefined {
+		let e: Element | undefined;
+		if (localName === "record") e = this.createrecord();
+		else e = undefined;
+		if (e) e.factory = this;
+		return e;
+	}
+}
+```
+
+Marshal / unmarshal:
+
+```ts
+import { Document } from "./out";
+import { record } from "./out/record";
+
+const r = new record();
+r._id = "r1";
+const xml = new Document().marshal(r);     // serialize
+const back = new Document().unmarshal(xml); // parse back through the Factory
+```
+
+## Notes
+
+- Integer-class XSD types (`integer`, `long`, `int`, `decimal`, ...) map to
+  `number`, not `bigint`. Values are exact only up to 2^53; this is the cost of
+  the ES2019 target.
+- fast-xml-parser `preserveOrder` keeps attribute order, whitespace, and
+  self-closing tags stable, so round-trips are byte-stable.
+- A `validate()` is emitted only for types carrying enforceable facets;
+  pattern facets are accepted but not checked.


### PR DESCRIPTION
Adds a documentation guide per output target under `docs/templates/` and refreshes the README.

**`docs/templates/<target>.md`** (ten guides — c-xml-expat, c-xml-expat-dom, c-json-jsonc, cpp-xml-expat, cpp-json-jsonc, python-sax, python-json, java-json, java-xml-stax, ts-xml). Each covers: the generate command, toolchain/dependencies, the generated API (type model, factory/subtype injection, marshal/unmarshal, facet validation, namespaces, base64/hex/lists), and a worked example — **written against real generated output**, not from memory (the agents caught real discrepancies, e.g. java-json uses Apache Commons Codec and has no factory, c-xml-expat-dom's inline-scalar storage, the expat exception-bridge).

**README refresh:**
- Target table → 10 rows (incl. the `c-xml-expat-dom` DOM variant) with a per-target docs link
- Replaced the stale Python-2 `Sample Output` dump with a pointer to the guides
- Testing section: ctest → the gtest binary / `run_parallel.py` (project convention)
- Requirements: added the optional test toolchains (node, json-c, JDK/Maven) that round-trips need
- Dropped the dead wiki link; corrected the "overridable factory" claim (java-json constructs directly); fixed a typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785022229&installation_id=141995922&pr_number=54&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F54&signature=cf4268c98a11f158e8d2861d4593984644d7df10ae29b46792cdbfddc9565503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->