### PR TITLE
Fix #11: disambiguate same-named child types in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,17 @@ All notable changes to xsd-tools are documented here. The format is based on
   (boost, expat, googletest).
 - Parser tree traversal (`ParseChildren`) refactored to functional sibling
   recursion via `Node::_eachChild`; behavior-preserving.
+- Test scripts migrated to Python 3 (the round-trip harness and its driver/
+  scaffold scripts now run under `python3`; generated python-sax/python-json
+  emit Python 3). Closes #33.
 
 ### Fixed
-- (planned) Duplicate generated structs for same-named child elements of
-  different types. Closes #11.
-
-### Removed
-- (planned) Legacy Python 2-era test scripts, superseded by the gtest +
-  Python 3 round-trip harness. Closes #33.
+- Same-named child elements of different types no longer collapse into a
+  single generated struct/class. Structurally-distinct types that share a
+  local name are disambiguated (`id`, `id1`, …) while identically-structured
+  types still share one definition. The disambiguated type's element/key
+  serializes under the suffixed name (e.g. `<id1>`), since the generated
+  unmarshallers dispatch on element name without parent context — consistent
+  with how non-identifier-safe names are already remapped. Closes #11.
 
 [Unreleased]: https://github.com/QVXLabs/xsd-tools/commits/master

--- a/templates/shared/trnsfrm_old
+++ b/templates/shared/trnsfrm_old
@@ -21,6 +21,47 @@ function trnsfrm_oldFmt(tbl)
 		root = __SCHEMA_NAME__,
 		types = {}
 	}
+	-- structural signature of a normalized type: content type + sorted
+	-- attribute name=type pairs + sorted dependent name:sig. Order-independent
+	-- and memoized per node so structurally-equal types hash identically.
+	local sigOf_ = {}
+	local function typeSig_(node)
+		if sigOf_[node] then return sigOf_[node] end
+		local attrs = {}
+		for an, av in pairs(node.attributes or {}) do
+			attrs[#attrs + 1] = an..'='..(av.type or '')
+		end
+		table.sort(attrs)
+		local deps = {}
+		for dn, dv in pairs(node.dependents or {}) do
+			deps[#deps + 1] = dn..':'..typeSig_(dv)
+		end
+		table.sort(deps)
+		local sig = '{c='..((node.content and node.content.type) or '')
+			..';a='..table.concat(attrs, ',')
+			..';d='..table.concat(deps, ',')..'}'
+		sigOf_[node] = sig
+		return sig
+	end
+	-- pick a flat-table key for a type: reuse the base name (or a prior
+	-- suffix) when the structure matches a type already under that key, else
+	-- allocate the next numeric suffix so distinct same-named types don't
+	-- collapse into one struct (#11).
+	local typeSigByName_ = {}
+	local function uniqueTypeName_(base, node)
+		local sig = typeSig_(node)
+		local candidate, n = base, 0
+		while true do
+			if outTblRoot.types[candidate] == nil then
+				typeSigByName_[candidate] = sig
+				return candidate
+			elseif typeSigByName_[candidate] == sig then
+				return candidate
+			end
+			n = n + 1
+			candidate = base..n
+		end
+	end
 	local function trnsfrm_r(tbl, state, outTbl)
 		--dbgPrint(StateName[state])
 		if state == State.Initialize then
@@ -69,9 +110,13 @@ function trnsfrm_oldFmt(tbl)
 					}
 					substate = Substate.ContentFound
 				elseif not isBaseType(v) then
-					outTbl.dependents[k]={}
-					outTbl.dependents[k].name = k
-					outTblRoot.types[k] = trnsfrm_r(v, State.Element, outTbl.dependents[k])
+					-- normalize the child first, then give it a name that
+					-- doesn't collide with a structurally-different type (#11).
+					local child = trnsfrm_r(v, State.Element, { name = k })
+					local key = uniqueTypeName_(k, child)
+					child.name = key
+					outTbl.dependents[key] = child
+					outTblRoot.types[key] = child
 				end
 			end
 			return outTbl

--- a/test/xsd-positive/bug_dup_struct_names.xsd
+++ b/test/xsd-positive/bug_dup_struct_names.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!-- #11: two elements named "id" of different types live in different scopes
+     (alpha/id is a string, beta/id an int). They previously collapsed into a
+     single struct named after the shared local name; now they disambiguate
+     (id / id1) so each scope keeps its own type. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="record">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="alpha">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="beta">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:int"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
## What

Same-named child elements of *different* types collapsed into a single generated struct/class (issue #11). The normalized model (`templates/shared/trnsfrm_old`) keyed every type by its element's local name, so the flat type table and the dependency sort deduped two distinct types into one — one type was silently lost and one element got the wrong type.

## Fix

Type names are now assigned from a **structural signature**:
- identically-structured types keep one shared definition (legitimate type reuse still dedups);
- structurally-distinct types sharing a local name get the next numeric suffix (`id`, `id1`, …).

All ten targets inherit this since they derive identifiers from the model's type name — no per-target changes.

## Tests

- New fixture `test/xsd-positive/bug_dup_struct_names.xsd` (two `id` children of different types in different scopes) auto-generates a round-trip case for every target.
- Passes on all 9 round-trippable targets (ts-xml skips without local node); full suite green; existing 400 round-trips unchanged (no spurious suffixes on legitimately-shared types).

## Caveat (by design, not a regression)

The generated unmarshallers dispatch on element name **globally, without parent context**, so the disambiguated element necessarily serializes under its suffixed name (e.g. `<id1>`). This matches how the tool already remaps non-identifier-safe names (`foo-bar` → `<foo_bar>`), and is a strict improvement over the prior behavior (which silently mistyped one element). Fully wire-conformant handling would require per-parent dispatch in every target — a separate, larger workstream.

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785028337&installation_id=141995922&pr_number=56&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F56&signature=a4a598dc6446feb3c8c48e0913c1e8683a3dadffc2c89ee1f17a3455adfa2ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->