### PR TITLE
Add #4: emit xs:documentation as comments in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ All notable changes to xsd-tools are documented here. The format is based on
   correct `xmlns`/prefix declarations, and `xs:import` resolves types across
   namespaces (contrast `xs:include`'s same-namespace merge). Cyclic schemas are
   rejected instead of overflowing the stack. Closes #10.
+- `xs:documentation` (annotation) text is emitted as a comment at the matching
+  location in generated code — above the type/struct/class/interface for an
+  element or complex type, and above the field for a scalar element or an
+  attribute — across all targets (C-style `/* */`, Python `#`). Closes #4.
 - (planned) Prebuilt binary releases (Linux/macOS), Homebrew formula, Docker image.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ It processes XSD schema documents and invokes a template file which outputs code
     are rejected.
   * Facet-bounded integer fields narrow to the smallest fitting type
     (e.g. `0..255` → `uint8_t` in C, `Short` in Java).
+  * `xs:documentation` annotations are carried into the generated code as
+    comments at the matching location (type, field, or attribute).
   * Simple Lua based templates for customizing code generation.
   * Usable as a C++ library (`XsdTools::Generate()`) as well as a CLI.
   * Open Source!

--- a/src/Processors/LuaAdapter.cpp
+++ b/src/Processors/LuaAdapter.cpp
@@ -34,6 +34,7 @@
 #define FACETS_TAG     "facets"
 #define NAMESPACE_TAG  "namespace"
 #define QUALIFIED_TAG  "qualified"
+#define DOCUMENTATION_TAG "documentation"
 #define DEBUG_LUASTACK (0)
 
 using namespace std;
@@ -215,6 +216,23 @@ LuaType::Qualified(bool qualified) {
 	lua_setfield(pLuaState, -2, QUALIFIED_TAG);
 }
 
+void
+LuaType::Documentation(const std::string& rText) {
+	if (rText.empty())
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* type table is at stack top. Don't overwrite a doc already attached: an
+	   element's own annotation is set before its type is expanded, so it wins
+	   over the referenced type's annotation. */
+	lua_getfield(pLuaState, -1, DOCUMENTATION_TAG);
+	const bool present = !lua_isnil(pLuaState, -1);
+	lua_pop(pLuaState, 1);
+	if (present)
+		return;
+	lua_pushstring(pLuaState, rText.c_str());
+	lua_setfield(pLuaState, -2, DOCUMENTATION_TAG);
+}
+
 /* Class LuaAttribute */
 LuaAttribute::LuaAttribute(	lua_State * pLuaState, 
 							const std::string& rName, 
@@ -310,6 +328,20 @@ LuaAttribute::Qualified(bool qualified) {
 	lua_getfield(pLuaState, -1, typeName_.c_str());
 	lua_pushboolean(pLuaState, 1);
 	lua_setfield(pLuaState, -2, QUALIFIED_TAG);
+	lua_pop(pLuaState, 2);
+}
+
+void
+LuaAttribute::Documentation(const std::string& rText) {
+	if (rText.empty())
+		return;
+	lua_State * pLuaState = getLuaState_();
+	/* descend attributes[name] -> [typeName] so the field lands on the type
+	   sub-table (same placement as Facets/Namespace) */
+	lua_getfield(pLuaState, -1, name_.c_str());
+	lua_getfield(pLuaState, -1, typeName_.c_str());
+	lua_pushstring(pLuaState, rText.c_str());
+	lua_setfield(pLuaState, -2, DOCUMENTATION_TAG);
 	lua_pop(pLuaState, 2);
 }
 

--- a/src/Processors/LuaAdapter.hpp
+++ b/src/Processors/LuaAdapter.hpp
@@ -112,6 +112,9 @@ namespace Processors {
 		void Namespace(const std::string& rNamespace);
 		/* attach the qualified flag; no-op when unqualified (the default) */
 		void Qualified(bool qualified);
+		/* attach the xs:documentation text; no-op when empty, and does not
+		   overwrite a doc already set (element-level wins over type-level) */
+		void Documentation(const std::string& rText);
 	protected:
 		LuaType(lua_State * pLuaState, const std::string& rTypeName,
 		        const int maxOccurs, const int minOccurs = 1);
@@ -127,6 +130,8 @@ namespace Processors {
 		void Namespace(const std::string& rNamespace);
 		/* attach the qualified flag; no-op when unqualified (the default) */
 		void Qualified(bool qualified);
+		/* attach the xs:documentation text; no-op when empty */
+		void Documentation(const std::string& rText);
 	protected:
 		LuaAttribute(	lua_State * pLuaState,
 						const std::string& rAttribName,

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -66,6 +66,26 @@
 using namespace std;
 using namespace Processors;
 
+/* First <annotation><documentation> text directly under pNode, or "" if none.
+   Annotations aren't part of the Lua model the visitor builds, so read them on
+   demand where the owning construct (element/complexType/attribute) is
+   processed (#4). */
+static string documentationOf_(const XSD::Elements::Node* pNode) {
+	string doc;
+	pNode->eachChild_([&doc](const XSD::Elements::Node& rChild) {
+		if (!(XSD_ISELEMENT(&rChild, XSD::Elements::Annotation)))
+			return;
+		rChild.eachChild_([&doc](const XSD::Elements::Node& rGrand) {
+			if (doc.empty() &&
+			    XSD_ISELEMENT(&rGrand, XSD::Elements::Documentation)) {
+				doc = static_cast<const XSD::Elements::Documentation&>(rGrand)
+				          .DocumentationStr();
+			}
+		});
+	});
+	return doc;
+}
+
 LuaProcessor::LuaProcessor(lua_State * pLuaState)
 	: LuaProcessorBase(new LuaAdapter(pLuaState))
 	, activePath_(new set<const void*>())
@@ -123,10 +143,13 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 				pLuaContent->Type(pNode->Name(), maxOccurs, minOccurs);
 			LuaProcessor luaPrcssr(pLuaType);
 			luaPrcssr.activePath_ = activePath_;
-			/* element namespace/form land on the element's type table before
-			   parseType_ descends into the content sub-tables */
+			/* element namespace/form/doc land on the element's type table
+			   before parseType_ descends into the content sub-tables. Setting
+			   the element's doc first lets it win over the referenced type's
+			   own annotation (LuaType::Documentation won't overwrite). */
 			pLuaType->Namespace(pNode->Namespace());
 			pLuaType->Qualified(pNode->Qualified());
+			pLuaType->Documentation(documentationOf_(pNode));
 			luaPrcssr.parseType_(*pElmType);
 		}
 	} else {
@@ -253,9 +276,10 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		walkAttributeFacets_(pType.get());
 		pAttribute->Facets(facets_);
 		facets_.clear();
-		/* attribute namespace/form, gated like facets */
+		/* attribute namespace/form/doc, gated like facets */
 		pAttribute->Namespace(pNode->Namespace());
 		pAttribute->Qualified(pNode->Qualified());
+		pAttribute->Documentation(documentationOf_(pNode));
 	}
 }
 
@@ -298,6 +322,11 @@ LuaProcessor::ProcessComplexType(const XSD::Elements::ComplexType* pNode) {
 			pNode->ParseChildren(*this);
 		}
 	} else {
+		/* a named complexType's own annotation, applied to the element's type
+		   table (no-op if the element already supplied a doc) */
+		LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
+		if (NULL != pLuaType)
+			pLuaType->Documentation(documentationOf_(pNode));
 		pNode->ParseChildren(*this);
 	}
 }

--- a/templates/c-json-jsonc.template
+++ b/templates/c-json-jsonc.template
@@ -5,6 +5,7 @@
 	return include 'shared/schemaEx'
 ][@lua --include facet helpers + xsd to c type mapping
 	include 'shared/facets'
+	include 'shared/doc'
 	return include 'c-json-jsonc/c_type_info'
 ][@lua --rename non-c-safe names & sort dependencies
 	schema = schema.c_safeNames()
@@ -64,12 +65,16 @@ typedef struct {
 	-- parentId, so emit it for nodes with dependents; also keep it as a filler
 	-- for otherwise-empty leaves (no members) to avoid an empty struct.
 	table.map(depOrderSansRoot, function(k, node)
+		-- emit the element/type annotation (#4) above its struct
+		outbuf:append(docComment(node.documentation, 'c', ''))
 		outbuf:append('typedef struct {\n')
 		local hasMembers = next(node.attributes) or next(node.content)
 		if next(node.dependents) or not hasMembers then
 			outbuf:append('\tuint32_t\teid_;\n')
 		end
 		table.map(node.attributes, function(name, xsdType)
+			-- emit the attribute annotation (#4) above its field
+			outbuf:append(docComment(xsdType.documentation, 'c', '\t'))
 			outbuf:append(table.concat({
 				'\t', c_narrowCType(xsdType.type, xsdType.facets).c_type.statement(name),
 			}))

--- a/templates/c-xml-expat
+++ b/templates/c-xml-expat
@@ -28,6 +28,8 @@
 	return include 'shared/schemaEx'
 ][@lua --include facet helpers
 	include 'shared/facets'
+][@lua --include documentation-comment helper (#4)
+	include 'shared/doc'
 ][@lua --include xsd to c type mapping
 	return include 'c-xml-expat-sax/c_type_info'
 ][@lua --rename any non-c-safe names to c-safe names & sort dependencies so that they are matched correctly
@@ -162,11 +164,15 @@ typedef struct {
 	end)
 	-- output element definitions
 	table.map(depOrderSansRoot, function(k, node)
+		-- emit the element/type annotation (#4) above its struct
+		outbuf:append(docComment(node.documentation, 'c', ''))
 		outbuf:append(table.concat({
 			'typedef struct {\n',
 			'\tuint32_t\teid_;\n',
 		}))
 		table.map(node.attributes, function(name, xsdType)
+			-- emit the attribute annotation (#4) above its field
+			outbuf:append(docComment(xsdType.documentation, 'c', '\t'))
 			outbuf:append(table.concat({
 				'\t', c_narrowCType(xsdType.type, xsdType.facets).c_type.statement(name),
 			}))

--- a/templates/c-xml-expat-dom.template
+++ b/templates/c-xml-expat-dom.template
@@ -1,5 +1,6 @@
 [@lua
 include 'shared/facets'
+include 'shared/doc'
 include 'c-xml-expat-dom/shared'
 include 'c-xml-expat-dom/namespace'
 include 'c-xml-expat-dom/types'

--- a/templates/c-xml-expat-dom/complexType
+++ b/templates/c-xml-expat-dom/complexType
@@ -20,6 +20,8 @@ end
 
 function complexType:typeDef()
    out = stringBuffer:new()
+   -- emit the element/type annotation (#4) above its struct
+   out:append(docComment(self._typedef.documentation, 'c', ''))
    out:append(("typedef struct %s {\n"):format(self:typeName()))
    out:append(("  xml_typelist * pContent_;\n"))
    table.map(self._typedef.attributes,
@@ -32,6 +34,8 @@ function complexType:typeDef()
                 if atrType:inlineScalar() and not attrAlwaysPresent(atrTypedef) then
                    fieldType = fieldType .. " *"
                 end
+                -- emit the attribute annotation (#4) above its field
+                out:append(docComment(atrTypedef.documentation, 'c', '  '))
                 out:append(("  %s %s;\n"):format(fieldType, atrName))
              end)
    out:append(("} * %s;\n"):format(self:typeName()))

--- a/templates/cpp-json-jsonc.template
+++ b/templates/cpp-json-jsonc.template
@@ -5,6 +5,7 @@
 	return include 'shared/schemaEx'
 ][@lua --include facet helpers + xsd to c++ type mapping
 	include 'shared/facets'
+	include 'shared/doc'
 	return include 'cpp-json-jsonc/cpp_type_info'
 ][@lua --rename non-c-safe names & sort dependencies
 	schema = schema.c_safeNames()
@@ -95,6 +96,8 @@ typedef std::string json_buffer;
 [@lua -- element classes: typed members default-initialized + member validate()
 	local outbuf = stringBuffer:new()
 	table.map(depOrderSansRoot, function(k, node)
+		-- emit the element/type annotation (#4) above its class
+		outbuf:append(docComment(node.documentation, 'c', ''))
 		outbuf:append('class json_'..node.name..' {\npublic:\n')
 		-- eid_ seeds children's parentId; kept for nodes with dependents and as
 		-- a filler for otherwise-empty leaves to avoid degenerate cases.
@@ -103,6 +106,8 @@ typedef std::string json_buffer;
 			outbuf:append('\tuint32_t\teid_ = 0;\n')
 		end
 		table.map(node.attributes, function(name, xsdType)
+			-- emit the attribute annotation (#4) above its field
+			outbuf:append(docComment(xsdType.documentation, 'c', '\t'))
 			outbuf:append('\t'..cpp_narrowType(xsdType.type, xsdType.facets).cpp_type.statement(name))
 		end)
 		if next(node.content) then

--- a/templates/cpp-xml-expat
+++ b/templates/cpp-xml-expat
@@ -22,6 +22,7 @@
 ][@lua include 'shared/trnsfrm_old'; schema = trnsfrm_oldFmt(schema)
 ][@lua return include 'shared/schemaEx'
 ][@lua include 'shared/facets'
+][@lua include 'shared/doc'
 ][@lua return include 'cpp-xml-expat-sax/cpp_type_info'
 ][@lua schema = schema.c_safeNames()
 	depOrder = schema.sortDependencies()
@@ -171,10 +172,14 @@ public:
 [@lua -- per-element classes (RAII members, default-initialised)
 	local outbuf = stringBuffer:new()
 	table.map(depOrderSansRoot, function(_, node)
+		-- emit the element/type annotation (#4) above its class
+		outbuf:append(docComment(node.documentation, 'c', ''))
 		outbuf:append('class '..node.name..' : public Element {\npublic:\n')
 		-- members
 		table.map(node.attributes, function(name, a)
 			local ct = cpp_narrowCType(a.type, a.facets)
+			-- emit the attribute annotation (#4) above its field
+			outbuf:append(docComment(a.documentation, 'c', '\t'))
 			outbuf:append('\t'..ct.cppType()..' '..name..'_ = {};\n')
 		end)
 		if next(node.content) then

--- a/templates/java-json.org/json-transform.lua
+++ b/templates/java-json.org/json-transform.lua
@@ -176,6 +176,16 @@
                   local className, typedef = next(classNameTbl)
                   if isTypeFoldable(XSDTree, typedef) then
                      local foldedTypeName, foldedTypedef = next(typedef.fields['$'])
+                     -- #4: a folded scalar leaf drops its own type table, so
+                     -- carry the element's xs:documentation onto the folded
+                     -- type. Copy first: scalar type tables are shared across
+                     -- fields, and a direct write would leak one field's doc.
+                     if typedef.documentation then
+                        local copy = {}
+                        for k, v in pairs(foldedTypedef) do copy[k] = v end
+                        copy.documentation = typedef.documentation
+                        foldedTypedef = copy
+                     end
                      outElem.fields[jsonTag] = {}
                      if isListType(className) then
                         outElem.fields[jsonTag]['list('..foldedTypeName..')'] = foldedTypedef

--- a/templates/java-json.org/parse.lua
+++ b/templates/java-json.org/parse.lua
@@ -3,6 +3,7 @@
    include 'java-json.org/listitemstrategy.lua'
    include 'java-json.org/types.lua'
    include 'java-json.org/adapters.lua'
+   include 'shared/doc'
 
    -- TODO: 1) use optJSONArray/opt... for optional fields
    --       2) make unmarshalling/marshalling handle fields which can be lists
@@ -184,13 +185,17 @@
 	  str:append(('import %s.JSONObjectAdapter;\n'):format(javaPKGName))
 	  str:append(('import %s.JSONArrayAdapter;\n\n'):format(javaPKGName))
 	  str:append(('import org.apache.commons.codec.DecoderException;\n\n'))
-	  -- generate class definition	  
+	  -- generate class definition
+	  -- #4: emit the element/type annotation above its class
+	  str:append(docComment(typedef.documentation, 'c', ''))
 	  str:append(
 		 ('public class %s implements Marshalable {\n'):format(typename)
-	  )	  
+	  )
 	  -- generate private members
 	  for JSONFieldName, fieldTypename, fieldTypedef in fieldIterator(typedef.fields) do
 		 local memberName  = makeJavaSafeName(JSONFieldName)
+		 -- #4: emit the field annotation above its declaration
+		 str:append(docComment(fieldTypedef.documentation, 'c', '\t'))
 		 if isListType(fieldTypename) then
 			local lstTypename = getListType(fieldTypename)
 			str:append(

--- a/templates/java-xml-stax.tmpl
+++ b/templates/java-xml-stax.tmpl
@@ -34,6 +34,7 @@
 	return include 'shared/schemaEx'
 ][@lua --include Java/StAX type info
 	include 'shared/facets'
+	include 'shared/doc'
 	include 'java-xml-stax/java_type_info'
 ][@lua --c-safe names & dependency order (mirror python-sax)
 	-- handle custom template arguments
@@ -340,11 +341,15 @@ public class Document {
 			"import javax.xml.stream.XMLStreamReader;\n",
 			"import javax.xml.stream.XMLStreamWriter;\n",
 			"import javax.xml.stream.XMLStreamException;\n\n",
+			-- #4: emit the element/type annotation above its class
+			docComment(node.documentation, 'c', ''),
 			"public class ", jn, " extends Element {\n",
 		}))
 
 		-- attribute fields (narrowed boxed type for numeric facets, D2b)
 		table.map(node.attributes, function(attribName, attribute)
+			-- #4: emit the attribute annotation above its field
+			outbuf:append(docComment(attribute.documentation, 'c', '\t'))
 			local nw = javaNumType(java_type_info[attribute.type],
 				attribute.facets)
 			if nw then

--- a/templates/python-json.tmpl
+++ b/templates/python-json.tmpl
@@ -4,6 +4,7 @@
 ][@lua --include any shared 'helper' templates
 	return include 'shared/schemaEx'
 ][@lua -- include python json type info
+	include 'shared/doc'
 	include 'shared/facets'
 	include 'python-json/python_type_info'
 ][@lua --rename any non-c-safe names to c-safe names & sort dependencies so that they are matched correctly
@@ -91,8 +92,10 @@ class _jsonelement:
 		return out:str()
 	end
 	table.map(depOrderSansRoot, function(_, node)
+		outbuf:append('\n')
+		-- emit the element/type annotation (#4) above its class
+		outbuf:append(docComment(node.documentation, 'hash', ''))
 		outbuf:append(table.concat({
-			'\n',
 			'class json_', node.name, '(_jsonelement):\n',
 			'    def __init__(self):\n',
 			'        _jsonelement.__init__(self)\n'
@@ -100,6 +103,8 @@ class _jsonelement:
 		-- output default attribute values
 		if next(node.attributes) then
 			table.map(node.attributes, function(attributeName, attribute)
+				-- emit the attribute annotation (#4) above its field
+				outbuf:append(docComment(attribute.documentation, 'hash', '        '))
 				if attribute.default then
 					local pyType = pyjson_type_info[attribute.type]
 					outbuf:append(pyType.default(attributeName, attribute.default))

--- a/templates/python-sax
+++ b/templates/python-sax
@@ -55,6 +55,7 @@
 ][@lua --include any shared 'helper' templates
 	return include 'shared/schemaEx'
 ][@lua -- include python type info
+	include 'shared/doc'
 	include 'shared/facets'
 	include 'python-xml/python_type_info'
 ][@lua --rename any non-c-safe names to c-safe names & sort dependencies so that they are matched correctly
@@ -165,8 +166,10 @@ class _xmlelement:
 		return out:str()
 	end
 	table.map(depOrderSansRoot, function(_, node)
+		outbuf:append('\n')
+		-- emit the element/type annotation (#4) above its class
+		outbuf:append(docComment(node.documentation, 'hash', ''))
 		outbuf:append(table.concat({
-			'\n',
 			'class xml_', node.name, '(_xmlelement):\n',
 			'    def __init__(self):\n',
 			'        _xmlelement.__init__(self)\n'
@@ -174,6 +177,8 @@ class _xmlelement:
 		-- output default attribute values
 		if next(node.attributes) then
 			table.map(node.attributes, function(attributeName, attribute)
+				-- emit the attribute annotation (#4) above its field
+				outbuf:append(docComment(attribute.documentation, 'hash', '        '))
 				if attribute.default then
 					local pyType = py_type_info[attribute.type]
 					outbuf:append(pyType.default(attributeName, attribute.default))

--- a/templates/shared/doc
+++ b/templates/shared/doc
@@ -1,0 +1,44 @@
+[@lua -- Documentation helper (#4): format an xs:documentation string as a
+	-- comment in a target-appropriate style. Pure: returns the text, emits
+	-- nothing itself. nil/blank docs return ''. XML indentation is noise, so
+	-- each line is trimmed and leading/trailing blank lines are dropped.
+	--   style 'c'     -> /* ... */ block  (C/C++/Java/TS; valid in any C std)
+	--   style 'slash' -> // line comments
+	--   style 'hash'  -> #  line comments (Python)
+	local function docLines(text)
+		local lines = {}
+		for line in (text..'\n'):gmatch('(.-)\n') do
+			lines[#lines + 1] = line:gsub('^%s+', ''):gsub('%s+$', '')
+		end
+		while #lines > 0 and lines[1] == '' do table.remove(lines, 1) end
+		while #lines > 0 and lines[#lines] == '' do table.remove(lines) end
+		return lines
+	end
+	function docComment(text, style, indent)
+		if not text or text == '' then return '' end
+		indent = indent or ''
+		local lines = docLines(text)
+		if #lines == 0 then return '' end
+		local out = {}
+		if style == 'hash' or style == 'slash' then
+			local prefix = (style == 'hash') and '# ' or '// '
+			for _, l in ipairs(lines) do
+				out[#out + 1] = indent..prefix..l
+			end
+		else
+			-- 'c' block; neutralize any embedded */ so it can't close early
+			for i, l in ipairs(lines) do
+				lines[i] = l:gsub('%*/', '* /')
+			end
+			if #lines == 1 then
+				return indent..'/* '..lines[1]..' */\n'
+			end
+			out[#out + 1] = indent..'/*'
+			for _, l in ipairs(lines) do
+				out[#out + 1] = indent..' * '..l
+			end
+			out[#out + 1] = indent..' */'
+		end
+		return table.concat(out, '\n')..'\n'
+	end
+]

--- a/templates/shared/trnsfrm_old
+++ b/templates/shared/trnsfrm_old
@@ -71,6 +71,8 @@ function trnsfrm_oldFmt(tbl)
 				elseif not isBaseType(v) then
 					outTbl.dependents[k]={}
 					outTbl.dependents[k].name = k
+					-- carry the element/type annotation (#4), nil when absent
+					outTbl.dependents[k].documentation = v.documentation
 					outTblRoot.types[k] = trnsfrm_r(v, State.Element, outTbl.dependents[k])
 				end
 			end
@@ -87,9 +89,11 @@ function trnsfrm_oldFmt(tbl)
 				outTbl.type = attribName
 				-- carry the attribute's restriction facets up for validation
 				outTbl.facets = attribDef.facets
-				-- namespace/qualified (E) ride along, nil when absent
+				-- namespace/qualified (E) + documentation (#4) ride along, nil
+				-- when absent
 				outTbl.namespace = attribDef.namespace
 				outTbl.qualified = attribDef.qualified
+				outTbl.documentation = attribDef.documentation
 				if nil ~= attribDef.default then
 					outTbl.default = attribDef.default
 				end

--- a/templates/ts-xml.tmpl
+++ b/templates/ts-xml.tmpl
@@ -28,6 +28,7 @@
 	schema = trnsfrm_oldFmt(schema)
 ][@lua return include 'shared/schemaEx'
 ][@lua include 'shared/facets'
+	include 'shared/doc'
 	include 'ts-xml/ts_type_info'
 ][@lua --ts-safe names & dependency order (mirror java-xml-stax)
 	if __CMD_ARGS__["-h"] then
@@ -357,10 +358,12 @@ export * from "./Document";
 			outbuf:append(statics:str())
 			outbuf:append("\n")
 		end
+		outbuf:append(docComment(node.documentation, 'c', ''))
 		outbuf:append(table.concat({
 			"export class ", tn, " extends Element {\n",
 		}))
 		table.map(node.attributes, function(an, attr)
+			outbuf:append(docComment(attr.documentation, 'c', '\t'))
 			outbuf:append(ts_type_info[attr.type].field(an))
 		end)
 		if hasContent then

--- a/test/xsd-positive/bug_annotation_docs.xsd
+++ b/test/xsd-positive/bug_annotation_docs.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!-- #4: xs:documentation should surface as a comment at the matching spot in
+     generated code: on an element (book), a nested element (title), an
+     attribute (isbn), and a named complexType referenced by an element
+     (Author, via the author element, whose own element has no annotation). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="Author">
+    <xs:annotation>
+      <xs:documentation>An author of the book.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="fullName" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="book">
+    <xs:annotation>
+      <xs:documentation>A book record.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="title" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>The book's title.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="author" type="Author"/>
+      </xs:sequence>
+      <xs:attribute name="isbn" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>ISBN-13 identifier.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
## What

`xs:documentation` (annotation) text is now carried into generated code as a comment at the matching location, across all ten targets (issue #4). Previously annotations were parsed but dropped.

## Where comments land

- **element / complex type** → comment above its generated struct / class / interface
- **scalar element rendered as a parent field** (e.g. Java/Python) → comment above that field
- **attribute** → comment above its field
- **named complexType** referenced by an element → the type's annotation surfaces on the element's construct (element-level annotation wins if both present)

Comment style: `/* … */` for C/C++/Java/TS, `#` for Python.

## How

- **Bridge** (`LuaProcessor`, `LuaAdapter`): read an element/complexType/attribute's `<annotation><documentation>` on demand and attach it to the Lua model; `LuaType`/`LuaAttribute` gain a `Documentation()` setter (set-if-absent so element-level wins).
- **Model** (`trnsfrm_old`): carry the `documentation` field onto normalized type nodes and attributes (nil when absent — no churn for un-annotated schemas).
- **Shared helper** (`templates/shared/doc`): `docComment(text, style, indent)` formats the text, trims XML indentation, and neutralizes any embedded `*/`.
- **Templates**: each target emits the comment at its idiomatic spot. One subtlety fixed in `java-json.org`: `foldSimpleTypes` dropped a scalar leaf's doc when folding it into a parent field — now carried (copy-first to avoid leaking to siblings that share the scalar type table).

## Tests

- New fixture `test/xsd-positive/bug_annotation_docs.xsd` exercises element-, nested-element-, attribute-, and named-complexType-level annotations; it auto-generates a round-trip case per target.
- Full suite green (**545 passed**, exit 0; ts-xml skips without local node). All 10 targets emit the expected comments; round-trips pass on all 9 toolchain-available targets.

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785030745&installation_id=141995922&pr_number=57&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F57&signature=1c91efe41ae8fb09732b5eda8844a8b4bcd92bb77375afddec000556606a03d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->