### PR TITLE
docs: backfill CHANGELOG for released versions 0.1.0–0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,4 +59,32 @@ All notable changes to xsd-tools are documented here. The format is based on
   unmarshallers dispatch on element name without parent context — consistent
   with how non-identifier-safe names are already remapped. Closes #11.
 
-[Unreleased]: https://github.com/QVXLabs/xsd-tools/commits/master
+## [0.1.2] - 2023-10-16
+
+### Fixed
+- Security vulnerabilities in test-case dependencies.
+- A gcc compile error.
+
+## [0.1.1] - 2021-11-22
+
+### Added
+- Conan support in the build system.
+- Overriding the C/C++ compiler and compile flags via environment variables.
+
+### Changed
+- The embedded Lua script engine is inlined into the executable via the
+  external `incbin` library.
+- Cleaned up the `c-xml-expat` template — tests pass again and the gcc/clang
+  compile warnings are fixed.
+
+## [0.1.0] - 2021-09-11
+
+### Added
+- First public release: generates marshalling/unmarshalling code from XSD
+  schemas via on-disk Lua templates (C, Python and Java output targets).
+- `XSDTOOLS_DATA` environment variable to locate the template/data directory.
+
+[Unreleased]: https://github.com/QVXLabs/xsd-tools/compare/0.1.2...HEAD
+[0.1.2]: https://github.com/QVXLabs/xsd-tools/compare/v0.1.1...0.1.2
+[0.1.1]: https://github.com/QVXLabs/xsd-tools/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/QVXLabs/xsd-tools/releases/tag/v0.1.0


### PR DESCRIPTION
Backfills the CHANGELOG with historical sections for the three pre-revitalization releases, reconstructed from their GitHub release notes, plus Keep-a-Changelog version compare links.

| Version | Date | Summary |
|---------|------|---------|
| 0.1.2 | 2023-10-16 | Fixed security issues in test-case deps; gcc compile fix |
| 0.1.1 | 2021-11-22 | Conan support; env-var compiler/flag overrides; incbin inlining; c-xml-expat cleanup |
| 0.1.0 | 2021-09-11 | First public release; `XSDTOOLS_DATA` env var |

Note: the `0.1.2` tag has no `v` prefix (unlike `v0.1.0`/`v0.1.1`), so the compare links use the tags as they actually exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785041005&installation_id=141995922&pr_number=59&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F59&signature=bc29673191380ed874cb4c121318ac3bcab1a5c9a0922e82ccc8f3412c9ec2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->