### PR TITLE
docs: add an examples/ walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ targets emit the right `xmlns`/prefixes, and `xs:import` brings in types from
 another namespace (`xs:include` continues to merge same-namespace documents).
 
 ### Sample Output ###
-Each [per-target guide](docs/templates/) shows real generated output and a
-marshal/unmarshal example for that target. For a quick look without reading a
-guide, just run the tool — e.g. `xsdb python-sax test/xsd-positive/testA002.xsd`
-prints the generated Python to stdout.
+[`examples/`](examples/) has a guided, end-to-end walkthrough — a small library
+catalog schema and the real generated output across several targets (showing
+annotations-as-comments, facet validation, and type narrowing). Each
+[per-target guide](docs/templates/) then shows that target's generated API and
+a marshal/unmarshal example. For a quick look, just run the tool — e.g.
+`xsdb python-sax examples/library.xsd` prints the generated Python to stdout.
 
 ### Usage Guide ###
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,74 @@
+# Examples
+
+A guided, end-to-end example. [`library.xsd`](library.xsd) is a small library
+catalog that exercises the features you'll care about in real schemas:
+
+- **nesting** — `library` → `book` (repeated, `maxOccurs="unbounded"`) →
+  `title` / `author` / `rating` / `genre`
+- an **attribute** — `book/@isbn`
+- **restriction facets** — `rating` is an `int` bounded to `1..5`; `genre` is a
+  string `enumeration` (`fiction` / `nonfiction` / `reference`)
+- **annotations** — `xs:documentation` on the schema and several elements
+
+Everything below is real output from `xsdb` on this schema.
+
+## Generate
+
+Generated code goes to **stdout**; redirect it, or use `--out-dir` for targets
+that emit multiple files. (Run from a build tree, or with an installed `xsdb`.)
+
+```sh
+xsdb python-sax       examples/library.xsd > library.py
+xsdb ts-xml.tmpl      examples/library.xsd            # TypeScript (multi-file)
+xsdb --out-dir out c-xml-expat examples/library.xsd   # C: writes out/*.h, *.c
+xsdb --list                                           # see all targets
+```
+
+See [`docs/templates/`](../docs/templates/) for a per-target guide (toolchain,
+generated API, marshal/unmarshal example).
+
+## What you get
+
+**Annotations become comments** at the matching spot. The `rating` element's
+`xs:documentation` lands above its generated type — here in `python-sax`:
+
+```python
+# Reader rating, 1-5 stars.
+class xml_rating(_xmlelement):
+```
+
+**Facets are enforced** in the generated unmarshaller, so invalid documents are
+rejected at parse time. `rating` (1..5) and `genre` (enumeration) in
+`python-sax`:
+
+```python
+raise ValueError("content: out of range")    # rating outside 1..5
+raise ValueError("content: not permitted")    # genre not in the enumeration
+```
+
+**Facet-bounded integers narrow to the smallest fitting type.** `rating`'s
+`1..5` range fits a byte, so `c-xml-expat` emits a `uint8_t` (not a 32-bit int):
+
+```c
+/* Reader rating, 1-5 stars. */
+typedef struct {
+	uint32_t	eid_;
+	uint8_t	Content_;
+} xml_rating;
+```
+
+The same schema in `ts-xml` keeps the annotation and types the field as a
+`number`:
+
+```ts
+/* Reader rating, 1-5 stars. */
+export class rating extends Element {
+	_text?: number;
+```
+
+## Round-trip
+
+Each target's generated code both **writes** (marshal) and **reads**
+(unmarshal) conforming XML/JSON. The per-target guides under
+[`docs/templates/`](../docs/templates/) show a complete marshal → unmarshal
+snippet for that language.

--- a/examples/library.xsd
+++ b/examples/library.xsd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A small library catalog. A self-contained demo schema for xsd-tools that
+     exercises nesting, attributes, repeated elements, restriction facets
+     (range + enumeration), and xs:documentation annotations. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="library">
+    <xs:annotation>
+      <xs:documentation>The catalog root: a collection of books.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="book" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="title" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>The book's title.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="author" type="xs:string"/>
+              <xs:element name="rating">
+                <xs:annotation>
+                  <xs:documentation>Reader rating, 1-5 stars.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                    <xs:maxInclusive value="5"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="genre">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="fiction"/>
+                    <xs:enumeration value="nonfiction"/>
+                    <xs:enumeration value="reference"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="isbn" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Adds an `examples/` directory (plan item A4) — a guided, end-to-end example that doubles as a quick smoke test of the headline features.

- **`examples/library.xsd`** — a small library-catalog schema exercising nesting (`library → book → …`), an attribute (`book/@isbn`), a repeated element (`maxOccurs="unbounded"`), restriction facets (`rating` int `1..5`, `genre` enumeration), and `xs:documentation` annotations.
- **`examples/README.md`** — a walkthrough with the **real** generated output across several targets, showing:
  - annotations emitted as comments (`# Reader rating, 1-5 stars.`),
  - facet validation (`raise ValueError("content: out of range")` / `not permitted`),
  - smallest-int narrowing (`rating` 1..5 → `uint8_t` in C).
- The top-level README's **Sample Output** section now points at `examples/` as the friendly entry point.

Verified all ten targets generate `library.xsd` cleanly.

Note on the other A4 items: the README install quickstart already landed (packaging PR), and there's no longer a dead wiki/Google-Code link in the README or docs (cleaned up during the revitalization), so this `examples/` directory is the remaining A4 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785046342&installation_id=141995922&pr_number=63&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F63&signature=ae9182e1b8eac5ce310997751422694267a00a854ca75d2d7dc85b645669be2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->