### PR TITLE
Parser robustness: tolerate codegen-irrelevant constructs, fail cleanly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ environment*.env
 
 # Claude planning docs — local only, not part of the repo
 /revitalize*.md
+
+# Stress-test corpus: downloaded public schemas (test/stress/fetch_schemas.sh)
+/test/stress/corpus/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ All notable changes to xsd-tools are documented here. The format is based on
   serializes under the suffixed name (e.g. `<id1>`), since the generated
   unmarshallers dispatch on element name without parent context — consistent
   with how non-identifier-safe names are already remapped. Closes #11.
+- Parser robustness: a malformed document with no usable root element, and an
+  `xs:import`/`xs:include` whose `schemaLocation` can't be loaded (e.g. an
+  `http://` URL), now report a clean error instead of crashing. Constructs that
+  don't affect the generated code but previously aborted parsing are tolerated
+  (parsed and ignored): identity constraints (`key`/`keyref`/`unique`/
+  `selector`/`field`), `anyAttribute`, `redefine`, `notation`, and markup
+  embedded in `xs:documentation`. Group references inside `sequence`/`choice`,
+  and top-level `group`/`attributeGroup` definitions and references, now resolve
+  (a parent-element check had rejected every top-level group/attributeGroup);
+  and a mixed-content complex type with an attribute no longer crashes. See
+  [docs/limitations.md](docs/limitations.md) for the capability map.
 
 ## [0.1.2] - 2023-10-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,7 @@ set(LIBXSDB_SOURCES
   src/XSDParser/Elements/Documentation.cpp
   src/XSDParser/Elements/All.cpp
   src/XSDParser/Elements/AppInfo.cpp
+  src/XSDParser/Elements/IgnoredNode.cpp
   src/Processors/ArrayType.cpp
   src/Processors/LuaProcessorBase.cpp
   src/Processors/LuaAdapter.cpp

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Namespaces are supported: schemas with a `targetNamespace` resolve and the XML
 targets emit the right `xmlns`/prefixes, and `xs:import` brings in types from
 another namespace (`xs:include` continues to merge same-namespace documents).
 
+For exactly what's supported, parsed-but-ignored, or unsupported (and how the
+tool fails when it can't proceed), see the
+[capability map](docs/limitations.md).
+
 ### Sample Output ###
 [`examples/`](examples/) has a guided, end-to-end walkthrough — a small library
 catalog schema and the real generated output across several targets (showing

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,47 @@
+# Capability map & limitations
+
+What xsd-tools does and doesn't do with an XSD, and how it fails when it can't.
+
+## Fully supported
+
+Elements, attributes (incl. `default`/`fixed`/`use`), `complexType` /
+`simpleType`, `sequence` / `choice` / `all`, named **group** and
+**attributeGroup** definitions and references (including refs inside model
+groups), `extension` / `restriction` over simple and complex content,
+`simpleType` `union` / `list`, **substitutionGroup**, **abstract** types,
+restriction **facets** (enforced in generated code), `xs:include` and
+`xs:import` (same- and cross-namespace), namespaces / `targetNamespace` /
+`elementFormDefault`, and `xs:documentation` (emitted as comments).
+
+## Parsed but ignored (no effect on generated code)
+
+These are accepted so real schemas that contain them work, but they don't
+influence the generated marshalling code:
+
+- Identity constraints — `key` / `keyref` / `unique` / `selector` / `field`
+- `anyAttribute`
+- `notation`
+- `redefine` — **skipped** (its redefinitions are dropped, not applied); a
+  schema that depends on `redefine` for its types will generate incomplete code
+- `nillable`, `xsi:type` (runtime type substitution), and element-level
+  `default` / `fixed`
+- Attributes on **mixed-content** complex types (mixed content is modelled as a
+  string; such attributes are dropped)
+- `xs:documentation` embedded markup — the text is gathered, tags are ignored
+
+## Not supported — fails with a clean error (never crashes)
+
+- A genuinely-unknown element → `InvallidChildXMLElement`
+- An `xs:import` / `xs:include` / `redefine` `schemaLocation` that can't be
+  loaded (e.g. an `http://` URL, or a missing local file) →
+  `ProtocolNotSupported` / a file-open error. Imports are resolved from the
+  local filesystem only.
+- Genuinely cyclic type derivation/reference → `CyclicTypeDefinition` (a
+  self-referential *definition* like a recursive `tree` is also rejected,
+  because the model inline-expands types)
+- Documents the bundled **TinyXML 2.6.2** can't parse (notably a `<!DOCTYPE>`
+  with an internal subset, and some encodings) → a parse error rather than
+  generated code. TinyXML is the EOL XML layer; replacing it is out of scope.
+
+All of the above are reported as a non-zero exit (see `xsdb`'s exit codes) — the
+parser does not crash on hostile or malformed input.

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -236,6 +236,12 @@ LuaProcessor::ProcessAttribute(const XSD::Elements::Attribute* pNode) {
 		SimpleTypeExtracter typeXtr;
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Type());
 		LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
+		/* attributes attach to a type table; in a content-only context (e.g. a
+		   mixed complexType, which re-enters with a LuaContent adapter) there is
+		   no type to attach to. Skip rather than dereference null — mixed-
+		   content attributes aren't modelled (documented limitation). */
+		if (NULL == pLuaType)
+			return;
 		unique_ptr<string> pDefault(nullptr);
 		unique_ptr<string> pFixed(nullptr);
 		unique_ptr<string> pUse(new string("optional"));

--- a/src/Processors/SimpleTypeExtracter.cpp
+++ b/src/Processors/SimpleTypeExtracter.cpp
@@ -59,7 +59,7 @@ SimpleTypeExtracter::ProcessUnion(const XSD::Elements::Union* pNode) {
 
 /* virtual */ void
 SimpleTypeExtracter::ProcessRestriction(const XSD::Elements::Restriction* pNode ) {
-	if (pNode->isParentSimpleContent() || pNode->isParentSimpleContent())
+	if (pNode->isParentSimpleContent() || pNode->isParentComplexContent())
 		pNode->ParseChildren(*this);
 	else {
 		unique_ptr<XSD::Types::BaseType> pType(pNode->Base());

--- a/src/XSDParser/Elements/AttributeGroup.cpp
+++ b/src/XSDParser/Elements/AttributeGroup.cpp
@@ -52,20 +52,27 @@ AttributeGroup::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	});
 }
 
+/* top-level == child of the <schema> root element, i.e. grandparent is the
+   document. (Its parent is the schema element, not the document — a parent==
+   DOCUMENT check wrongly rejected every top-level attributeGroup.) */
+static bool isTopLevel_(const TiXmlElement& rElm) {
+	const TiXmlNode* pParent = rElm.Parent();
+	return NULL != pParent && NULL != pParent->Parent() &&
+	       TiXmlNode::TINYXML_DOCUMENT == pParent->Parent()->Type();
+}
+
 void
 AttributeGroup::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	/* a ref and a name are not allowed */
 	if (HasName() && HasRef())
 		throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
-	/* a name is only allowed when it's parent element is a schema */
-	if (HasName()) {
-		if (Node::GetXMLElm().Parent()->Type() != TiXmlNode::TINYXML_DOCUMENT)
-			throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
-	}
+	/* a named attributeGroup definition must be top-level */
+	if (HasName() && !isTopLevel_(Node::GetXMLElm()))
+		throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
 	if (HasRef()) {
 		std::unique_ptr<AttributeGroup> pRefGroup(RefGroup());
-		/* a name is only allowed when it's parent element is a schema */
-		if (pRefGroup->GetXMLElm().Parent()->Type() != TiXmlNode::TINYXML_DOCUMENT)
+		/* the referenced attributeGroup must likewise be top-level */
+		if (!isTopLevel_(pRefGroup->GetXMLElm()))
 			throw XMLException(pRefGroup->GetXMLElm(), XMLException::InvalidAttribute);
 	}
 	rProcessor.ProcessAttributeGroup(this);

--- a/src/XSDParser/Elements/Choice.cpp
+++ b/src/XSDParser/Elements/Choice.cpp
@@ -29,6 +29,7 @@
 #include "./src/XSDParser/Elements/Choice.hpp"
 #include "./src/XSDParser/Elements/Element.hpp"
 #include "./src/XSDParser/Elements/Sequence.hpp"
+#include "./src/XSDParser/Elements/Group.hpp"
 #include "./src/XSDParser/Elements/Annotation.hpp"
 #include "./src/XSDParser/Elements/Any.hpp"
 #include "./src/XSDParser/ProcessorBase.hpp"
@@ -52,6 +53,7 @@ Choice::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 			XSD_ISELEMENT(&rNode, Choice) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Sequence) ||
+			XSD_ISELEMENT(&rNode, Group) ||
 			XSD_ISELEMENT(&rNode, Any)) {
 			rNode.ParseElement(rProcessor);
 		} else

--- a/src/XSDParser/Elements/Documentation.cpp
+++ b/src/XSDParser/Elements/Documentation.cpp
@@ -43,11 +43,11 @@ Documentation::Documentation(const Documentation& cpy)
 
 void
 Documentation::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	/* no children allowed */
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
+	/* xs:documentation content is opaque mixed content (it routinely embeds
+	   HTML — <div>, <p>, ... — as in xml.xsd / XMLSchema.xsd), so do NOT parse
+	   it as XSD. The text is read separately via DocumentationStr(); calling
+	   FirstChild() here would feed that markup to the strict node factory and
+	   throw. No-op. */
 }
 
 void
@@ -55,19 +55,22 @@ Documentation::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	rProcessor.ProcessDocumentation(this);
 }
 
+/* Collect all descendant text, descending into any embedded markup.
+   xs:documentation is opaque mixed content and commonly wraps text in HTML
+   (<p>, <em>, ...); gather the text rather than throwing on element children. */
+static std::string collectText_(const TiXmlNode& rNode) {
+	std::string txt;
+	for (const TiXmlNode* p = rNode.FirstChild(); NULL != p;
+	     p = p->NextSibling()) {
+		if (TiXmlNode::TINYXML_TEXT == p->Type())
+			txt += p->Value();
+		else if (TiXmlNode::TINYXML_ELEMENT == p->Type())
+			txt += collectText_(*p);
+	}
+	return txt;
+}
+
 std::string
 Documentation::DocumentationStr() const noexcept(false) {
-	if (Node::HasContent()) {
-		std::string retTxt;
-		const TiXmlNode* pXmlNode = Node::GetXMLElm().FirstChild();
-		for ( ; NULL != pXmlNode; pXmlNode = pXmlNode->NextSibling()) {
-			if (TiXmlNode::TINYXML_TEXT == pXmlNode->Type())
-				retTxt += pXmlNode->Value();
-			else
-				throw XMLException(GetXMLElm(), XMLException::InvallidChildXMLElement);
-		}
-		return retTxt;
-	} else {
-		return std::string("");
-	}
+	return collectText_(Node::GetXMLElm());
 }

--- a/src/XSDParser/Elements/Group.cpp
+++ b/src/XSDParser/Elements/Group.cpp
@@ -59,20 +59,28 @@ Group::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	});
 }
 
+/* A group definition is top-level when it is a child of the <schema> root
+   element, i.e. its grandparent is the document. (Its *parent* is the schema
+   element, not the document — an earlier parent==DOCUMENT check wrongly
+   rejected every top-level group.) */
+static bool isTopLevel_(const TiXmlElement& rElm) {
+	const TiXmlNode* pParent = rElm.Parent();
+	return NULL != pParent && NULL != pParent->Parent() &&
+	       TiXmlNode::TINYXML_DOCUMENT == pParent->Parent()->Type();
+}
+
 void
 Group::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 	/* a ref and a name are not allowed */
 	if (HasName() && HasRef())
 		throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
-	/* a name is only allowed when it's parent element is a schema */
-	if (HasName()) {
-		if (Node::GetXMLElm().Parent()->Type() != TiXmlNode::TINYXML_DOCUMENT)
-			throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
-	}
+	/* a named group definition must be top-level */
+	if (HasName() && !isTopLevel_(Node::GetXMLElm()))
+		throw XMLException(Node::GetXMLElm(), XMLException::InvalidAttribute);
 	if (HasRef()) {
 		std::unique_ptr<Group> pRefGroup(RefGroup());
-		/* a name is only allowed when it's parent element is a schema */
-		if (pRefGroup->GetXMLElm().Parent()->Type() != TiXmlNode::TINYXML_DOCUMENT)
+		/* the referenced group must likewise be a top-level definition */
+		if (!isTopLevel_(pRefGroup->GetXMLElm()))
 			throw XMLException(pRefGroup->GetXMLElm(), XMLException::InvalidAttribute);
 	}
 	/* verify that 'maxOccurs' is not negative unless its -1 (unbounded) */

--- a/src/XSDParser/Elements/IgnoredNode.cpp
+++ b/src/XSDParser/Elements/IgnoredNode.cpp
@@ -1,0 +1,41 @@
+/*
+ * IgnoredNode.cpp
+ *
+ *  This file is part of xsd-tools.
+ *
+ *  xsd-tools is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  xsd-tools is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "./src/XSDParser/Elements/IgnoredNode.hpp"
+
+using namespace XSD;
+using namespace XSD::Elements;
+
+IgnoredNode::IgnoredNode(const TiXmlElement& elm, const Parser& rParser)
+	: Node(elm, rParser)
+{ }
+
+IgnoredNode::IgnoredNode(const IgnoredNode& cpy)
+	: Node(cpy)
+{ }
+
+/* no-op: a codegen-irrelevant construct contributes nothing and is not
+   recursed into (so e.g. key/selector/field grandchildren are never visited) */
+void
+IgnoredNode::ParseChildren(BaseProcessor& rProcessor) const noexcept(false)
+{ }
+
+void
+IgnoredNode::ParseElement(BaseProcessor& rProcessor) const noexcept(false)
+{ }

--- a/src/XSDParser/Elements/IgnoredNode.hpp
+++ b/src/XSDParser/Elements/IgnoredNode.hpp
@@ -1,0 +1,47 @@
+/*
+ * IgnoredNode.hpp
+ *
+ *  This file is part of xsd-tools.
+ *
+ *  xsd-tools is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  xsd-tools is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef IGNOREDNODE_HPP_
+#define IGNOREDNODE_HPP_
+#ifndef TIXML_USE_STL
+#	define TIXML_USE_STL
+#endif /* TIXML_USE_STL */
+#include <tinyxml.h>
+#include "./src/XSDParser/Elements/Node.hpp"
+namespace XSD {
+	namespace Elements {
+		/* A no-op Node for valid XSD constructs that are irrelevant to
+		   marshalling codegen — identity constraints (key/keyref/unique/
+		   selector/field), anyAttribute, redefine, notation. The factory maps
+		   those tags here so the strict parser tolerates (rather than throws on)
+		   real-world schemas that merely contain them. It contributes nothing to
+		   the model and does not recurse into its children. */
+		class IgnoredNode : public Node {
+		private:
+			IgnoredNode();
+		public:
+			IgnoredNode(const TiXmlElement& elm, const Parser& rParser);
+			IgnoredNode(const IgnoredNode& cpy);
+			void ParseChildren(BaseProcessor& rProcessor) const noexcept(false);
+			void ParseElement(BaseProcessor& rProcessor) const noexcept(false);
+		};
+	}	/* namespace Elements */
+}	/* namespace XSD */
+
+#endif /* IGNOREDNODE_HPP_ */

--- a/src/XSDParser/Elements/Import.cpp
+++ b/src/XSDParser/Elements/Import.cpp
@@ -59,6 +59,10 @@ Import::QuerySchema() const noexcept(false) {
 	if (NULL == pSchema_ && HasSchema()) {
 		std::string uri = resolveSchemaURI_("schemaLocation");
 		pSchema_ = Node::GetParser().Parse(uri);
+		/* Parse returns NULL for an unsupported/unfetchable location (e.g. an
+		   http:// schemaLocation); throw cleanly instead of dereferencing it. */
+		if (NULL == pSchema_)
+			throw XMLException(GetXMLElm(), XMLException::ProtocolNotSupported);
 		/* index the imported namespace so cross-doc refs resolve by URI */
 		Node::GetParser().RegisterNamespace(pSchema_->TargetNamespace(), uri);
 	}

--- a/src/XSDParser/Elements/Include.cpp
+++ b/src/XSDParser/Elements/Include.cpp
@@ -58,6 +58,10 @@ const Schema*
 Include::QuerySchema() const noexcept(false) {
 	if (NULL == pSchema_) {
 		pSchema_ = Node::GetParser().Parse(resolveSchemaURI_("schemaLocation"));
+		/* Parse returns NULL for an unsupported/unfetchable location; throw
+		   cleanly instead of returning a NULL schema callers dereference. */
+		if (NULL == pSchema_)
+			throw XMLException(GetXMLElm(), XMLException::ProtocolNotSupported);
 	}
 	return pSchema_;
 }

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -60,6 +60,7 @@
 #include "./src/XSDParser/Elements/Documentation.hpp"
 #include "./src/XSDParser/Elements/All.hpp"
 #include "./src/XSDParser/Elements/AppInfo.hpp"
+#include "./src/XSDParser/Elements/IgnoredNode.hpp"
 
 #define DEBUG_CONSTRUCTION (0)
 
@@ -246,10 +247,21 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 			[](const TiXmlElement& e, const Parser& p) -> Node*
 				{ return new AppInfo(e, p); } },
 	};
+	/* Valid XSD constructs that don't affect marshalling codegen: parse them as
+	   a no-op IgnoredNode so schemas that merely contain them don't throw.
+	   Scoped whitelist — genuinely-unknown tags still throw below. */
+	static const char* const kIgnoredTags[] = {
+		"key", "keyref", "unique", "selector", "field",
+		"anyAttribute", "redefine", "notation",
+	};
 	const std::string elementName = stripPrefix_(pElm->ValueStr());
 	for (const auto& rEntry : kTable) {
 		if (boost::iequals(std::string(rEntry.pTag), elementName))
 			return rEntry.pMake(*pElm, rParser);
+	}
+	for (const char* pTag : kIgnoredTags) {
+		if (boost::iequals(std::string(pTag), elementName))
+			return new IgnoredNode(*pElm, rParser);
 	}
 	throw XMLException(*pElm, XMLException::InvallidChildXMLElement);
 	return NULL;
@@ -422,7 +434,10 @@ findSibling_(std::unique_ptr<Node> pNode,
 		const std::function<bool(const Node&)>& rFn) noexcept(false) {
 	if (NULL == pNode.get())
 		return false;
-	if (rFn(*pNode))
+	/* IgnoredNode (anyAttribute, identity constraints, redefine, notation) is
+	   transparent to traversal: skip rFn so context-checking ParseChildren
+	   overrides don't reject it, then continue down the sibling chain. */
+	if (!(XSD_ISELEMENT(pNode.get(), IgnoredNode)) && rFn(*pNode))
 		return true;
 	return findSibling_(std::unique_ptr<Node>(pNode->NextSibling()), rFn);
 }
@@ -448,9 +463,12 @@ Node::ContentElement(const char* pElemName) const noexcept(false) {
 	return pElm;
 }
 
-const TiXmlElement& 
+const TiXmlElement&
 Node::QueryRootElement() const {
 	const TiXmlDocument * pNode = GetXmlDocument().ToDocument();
+	/* a malformed/rootless document would otherwise deref null here */
+	if (NULL == pNode || NULL == pNode->RootElement())
+		throw XMLException(rXmlElm_, XMLException::NodeNotFound);
 	return *(pNode->RootElement());
 }
 

--- a/src/XSDParser/Elements/Sequence.cpp
+++ b/src/XSDParser/Elements/Sequence.cpp
@@ -46,6 +46,7 @@ Sequence::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 			XSD_ISELEMENT(&rNode, Choice) ||
 			XSD_ISELEMENT(&rNode, Annotation) ||
 			XSD_ISELEMENT(&rNode, Sequence) ||
+			XSD_ISELEMENT(&rNode, Group) ||
 			XSD_ISELEMENT(&rNode, Any)) {
 			rNode.ParseElement(rProcessor);
 		} else

--- a/src/XSDParser/Parser.cpp
+++ b/src/XSDParser/Parser.cpp
@@ -67,22 +67,29 @@ Elements::Schema*
 Parser::Parse(const std::string& rUri) const noexcept(false) {
 	/* search if the document has already been parsed */
 	if (DocumentRecord* pRec = findByUri_(rUri)) {
+		if (NULL == pRec->pDocument_->RootElement())
+			throw XMLException(*pRec->pDocument_);
 		return new Elements::Schema(*(pRec->pDocument_->RootElement()),
 			*this, rUri);
 	} else {
 		docLst_.push_back(new DocumentRecord(new TiXmlDocument(), rUri));
 		TiXmlDocument * pDoc = docLst_.back()->pDocument_;
 		pDoc->SetTabSize(4);
-		/* parse protocol portion */
+		/* parse protocol portion. LoadFile can return true yet leave no root
+		   element (TinyXML silently mis-parses some DOCTYPE/encoding cases);
+		   guard RootElement() so a malformed document throws instead of binding
+		   a null reference into Schema and segfaulting later. */
 		if (0 == rUri.find(PROTO_FILE)) {
 			std::string path = rUri.substr(sizeof(PROTO_FILE) - 1);
-			if( !pDoc->LoadFile(path, TIXML_ENCODING_UTF8) ) {
+			if( !pDoc->LoadFile(path, TIXML_ENCODING_UTF8)
+			    || NULL == pDoc->RootElement() ) {
 				throw XMLException(*pDoc);
 			}
 			return new Elements::Schema(*pDoc->RootElement(), *this, rUri);
 		} else if (std::string::npos == rUri.find("://")) {
 			/* if no protocol specified then assume it is a local file */
-			if( !pDoc->LoadFile(rUri, TIXML_ENCODING_UTF8) ) {
+			if( !pDoc->LoadFile(rUri, TIXML_ENCODING_UTF8)
+			    || NULL == pDoc->RootElement() ) {
 				throw XMLException(*pDoc);
 			}
 			return new Elements::Schema(*pDoc->RootElement(), *this, rUri);

--- a/src/luaScriptAdapter.cpp
+++ b/src/luaScriptAdapter.cpp
@@ -128,9 +128,13 @@ LuaScriptAdapterExecute_error:
 	case LUA_ERRERR:
 		throw LuaException("Error running lua error handler", err);
 		break;
-	default:
-		throw LuaException(lua_tostring(pLuaState_, -1), err);
+	default: {
+		/* lua_tostring returns NULL when the error object isn't a string (e.g.
+		   `error({})`); don't pass NULL to the LuaException(std::string) ctor. */
+		const char* pMsg = lua_tostring(pLuaState_, -1);
+		throw LuaException(pMsg ? pMsg : "non-string Lua error", err);
 		break;
+	}
 	}
 }
 

--- a/src/xsdtools.cpp
+++ b/src/xsdtools.cpp
@@ -26,6 +26,7 @@
 #endif
 #include <cerrno>
 #include <fstream>
+#include <regex>
 #include <iostream>
 #include <ostream>
 #include <sstream>
@@ -166,6 +167,14 @@ namespace XsdTools {
 				size_t start = pos + marker.size();
 				size_t end = line.find(' ', start);
 				name = line.substr(start, end - start);
+				/* a FILE: marker must name a plain file under outDir: a leading
+				   alnum/underscore then alnum/._- only. This rejects empty,
+				   path separators, "..", and dotfiles, so a template can't
+				   write outside the output directory. */
+				static const std::regex kSafeName("[A-Za-z0-9_][A-Za-z0-9._-]*");
+				if (!std::regex_match(name, kSafeName))
+					throw Core::ResourceException(
+						"Invalid '/* FILE: */' marker name: '" + name + "'");
 				pending.clear();
 				sawContent = false;
 			} else {

--- a/templates/c-xml-expat
+++ b/templates/c-xml-expat
@@ -41,7 +41,6 @@
 	-- map xsd types to unique c-types
 	uniqueCTypes = {}
 	table.map(uniqueXSDTypes, function(_, v)
-		dbgPrint(v)
 		local ctype = c_type_info[v]
 		uniqueCTypes[ctype] = ctype
 		if 'c_list' == ctype.type then

--- a/test/stress/fetch_schemas.sh
+++ b/test/stress/fetch_schemas.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Download a curated set of large/complex public XSDs for stress testing.
+# Tolerant of individual download failures (sites go down); reports what it got.
+# Output: test/stress/corpus/  (gitignored — not committed; these are upstream
+# documents with varied licenses, fetched on demand for discovery only).
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+dest="$here/corpus"
+mkdir -p "$dest"
+
+# Each entry: <filename>|<url>. Chosen to exercise the risky constructs:
+#   XMLSchema.xsd  -> heavy anyAttribute; the schema-for-schemas
+#   xhtml11        -> xs:redefine (XHTML modularization)
+#   docbook        -> huge, deep nesting, xlink import
+#   soap/wsdl      -> anyAttribute, import chains
+#   UBL invoice    -> very large, identity constraints, big import graph
+schemas=(
+  "xmlschema.xsd|https://www.w3.org/2001/XMLSchema.xsd"
+  "xml.xsd|https://www.w3.org/2001/xml.xsd"
+  "xhtml1-strict.xsd|https://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd"
+  "xhtml11.xsd|https://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd"
+  "docbook.xsd|https://docbook.org/xml/5.0/xsd/docbook.xsd"
+  "soap-envelope.xsd|https://schemas.xmlsoap.org/soap/envelope/"
+  "wsdl.xsd|https://schemas.xmlsoap.org/wsdl/"
+  "xmldsig.xsd|https://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd"
+  "kml.xsd|https://developers.google.com/kml/schema/kml22gx.xsd"
+)
+
+ok=0; fail=0
+for entry in "${schemas[@]}"; do
+  name="${entry%%|*}"; url="${entry#*|}"
+  if curl -fsSL --max-time 45 "$url" -o "$dest/$name" 2>/dev/null \
+     && [ -s "$dest/$name" ]; then
+    printf "  ok    %-22s %8s bytes\n" "$name" "$(wc -c <"$dest/$name")"
+    ok=$((ok+1))
+  else
+    printf "  FAIL  %-22s %s\n" "$name" "$url"
+    rm -f "$dest/$name"; fail=$((fail+1))
+  fi
+done
+echo "fetched $ok, failed $fail  ->  $dest"

--- a/test/stress/run_stress.py
+++ b/test/stress/run_stress.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Stress / robustness probe: run xsdb over a corpus of schemas across every
+output target and categorize the outcomes. This is a DISCOVERY tool — failures
+are the point (it surfaces unsupported XSD constructs), so it always exits 0 and
+prints a markdown report.
+
+Usage: run_stress.py [xsdb-binary] [corpus-dir]
+  defaults: build/xsdb  test/stress/corpus
+"""
+import glob
+import os
+import subprocess
+import sys
+from collections import Counter, defaultdict
+
+# The 10 emit targets + the "test" parser-model dump (the purest "does it parse"
+# check — if `test` fails the schema didn't parse at all).
+TARGETS = [
+    "test", "c-xml-expat", "c-xml-expat-dom.template", "c-json-jsonc.template",
+    "cpp-xml-expat", "cpp-json-jsonc.template", "python-sax", "python-json.tmpl",
+    "java-json.org.tmpl", "java-xml-stax.tmpl", "ts-xml.tmpl",
+]
+
+# xsdb exit codes (src/main.cpp)
+EXIT = {0: "ok", 1: "general", 2: "usage", 3: "no-file",
+        4: "parse(XMLException)", 5: "template(Lua)", 6: "resource"}
+
+# stderr markers -> the XSD feature/exception responsible
+MARKERS = ["InvallidChildXMLElement", "CyclicTypeDefinition", "UndefiniedXSDType",
+           "UnsupportedXSDType", "MissingElement", "MissingChildXMLElement",
+           "NamespaceMismatch", "SubstitutionGroup", "URINotValid",
+           "ProtocolNotSupported"]
+
+
+def marker_of(stderr):
+    for m in MARKERS:
+        if m in stderr:
+            return m
+    return ""
+
+
+def main(argv):
+    xsdb = argv[1] if len(argv) > 1 else "build/xsdb"
+    corpus = argv[2] if len(argv) > 2 else "test/stress/corpus"
+    schemas = sorted(glob.glob(os.path.join(corpus, "*.xsd")))
+    if not schemas:
+        print(f"no schemas in {corpus} (run fetch_schemas.sh first)")
+        return 0
+
+    exit_counts = Counter()
+    marker_counts = Counter()
+    per_schema = {}            # schema -> list[(target, rc, marker)]
+    fully_ok = []
+
+    for schema in schemas:
+        rows = []
+        ok_all = True
+        for t in TARGETS:
+            try:
+                p = subprocess.run([xsdb, t, schema], capture_output=True,
+                                   text=True, timeout=120)
+                rc, marker = p.returncode, marker_of(p.stderr)
+            except subprocess.TimeoutExpired:
+                rc, marker = 124, "TIMEOUT"
+            except Exception as e:                       # noqa: BLE001
+                rc, marker = 999, type(e).__name__
+            rows.append((t, rc, marker))
+            exit_counts[rc] += 1
+            if marker:
+                marker_counts[marker] += 1
+            if rc != 0:
+                ok_all = False
+        per_schema[schema] = rows
+        if ok_all:
+            fully_ok.append(schema)
+
+    # ---- report (markdown) ----
+    n = len(schemas)
+    print(f"# Stress report — {n} schemas x {len(TARGETS)} targets\n")
+    print(f"- binary: `{xsdb}`")
+    print(f"- fully-clean schemas (all targets exit 0): "
+          f"**{len(fully_ok)}/{n}**\n")
+
+    print("## Outcomes by exit code\n")
+    for rc in sorted(exit_counts):
+        print(f"- `{rc}` {EXIT.get(rc, '?'):<22} {exit_counts[rc]}")
+    print()
+
+    print("## Failures by XSD construct / exception\n")
+    if marker_counts:
+        for m, c in marker_counts.most_common():
+            print(f"- **{m}**: {c}")
+    else:
+        print("- (none)")
+    print()
+
+    print("## Per-schema (target: exit/marker for non-ok)\n")
+    for schema in schemas:
+        base = os.path.basename(schema)
+        bad = [(t, rc, mk) for (t, rc, mk) in per_schema[schema] if rc != 0]
+        if not bad:
+            print(f"- `{base}` — all targets ok")
+            continue
+        # if `test` (parse) failed, the schema doesn't parse at all
+        parse = next((rc for (t, rc, _) in per_schema[schema] if t == "test"),
+                     None)
+        tag = "DOES-NOT-PARSE" if parse not in (0, None) else "parses; gen gaps"
+        detail = ", ".join(f"{t}:{rc}{('/'+mk) if mk else ''}"
+                           for (t, rc, mk) in bad)
+        print(f"- `{base}` — {tag} — {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/xsd-negative/bug_http_import.xsd
+++ b/test/xsd-negative/bug_http_import.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: an unfetchable http schemaLocation must throw cleanly
+     (ProtocolNotSupported), not segfault on a null imported schema. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ex="http://example.com/ns">
+  <xs:import namespace="http://example.com/ns"
+             schemaLocation="http://example.com/remote.xsd"/>
+  <xs:element name="root" type="ex:RemoteType"/>
+</xs:schema>

--- a/test/xsd-negative/bug_no_root.xsd
+++ b/test/xsd-negative/bug_no_root.xsd
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a document with no root element must throw cleanly,
+     not segfault on a null RootElement(). -->

--- a/test/xsd-negative/bug_unknown_tag.xsd
+++ b/test/xsd-negative/bug_unknown_tag.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a genuinely-unknown construct must still throw
+     (the ignored-construct whitelist is scoped, not blanket tolerance). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:bogusConstruct/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_any_attribute.xsd
+++ b/test/xsd-positive/bug_any_attribute.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: xs:anyAttribute is codegen-irrelevant and must not
+     crash the parser (it is parsed as a no-op and ignored). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="widget">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="label" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:string"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_attribute_group.xsd
+++ b/test/xsd-positive/bug_attribute_group.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a top-level attributeGroup definition referenced from
+     a complexType (the top-level-attributeGroup parent check). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="commonAttrs">
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="lang" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:element name="widget">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="label" type="xs:string"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="commonAttrs"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_doc_markup.xsd
+++ b/test/xsd-positive/bug_doc_markup.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: xs:documentation content is opaque mixed content and
+     may embed markup; it must not be parsed as XSD. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="note" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>A note. <p>With <em>HTML</em> markup.</p></xs:documentation>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_group_ref.xsd
+++ b/test/xsd-positive/bug_group_ref.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a top-level named group definition referenced from a
+     sequence (group refs in sequence/choice, and the top-level-group check). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="nameGroup">
+    <xs:sequence>
+      <xs:element name="first" type="xs:string"/>
+      <xs:element name="last" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="person">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="nameGroup"/>
+        <xs:element name="age" type="xs:int"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_identity_constraints.xsd
+++ b/test/xsd-positive/bug_identity_constraints.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: key/keyref/unique + selector/field are ignored and
+     must not crash the parser. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="catalog">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="sku" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="uniqueSku">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="sku"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_mixed_attribute.xsd
+++ b/test/xsd-positive/bug_mixed_attribute.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a mixed-content complexType that also has an attribute
+     must not crash (the attribute is not modelled on mixed content). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="para">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element name="emphasis" type="xs:string" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="class" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/xsd-positive/bug_notation.xsd
+++ b/test/xsd-positive/bug_notation.xsd
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!-- robustness #stress: a top-level xs:notation is ignored, not a crash. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:notation name="png" public="image/png"/>
+  <xs:element name="image" type="xs:string"/>
+</xs:schema>


### PR DESCRIPTION
## Summary

Stress-testing against large public schemas surfaced two classes of problems: constructs the parser **crashed** on, and common constructs it **rejected** outright — even when they don't affect the generated marshalling code. This makes the parser tolerant of those constructs and turns the remaining unparseable inputs into clean errors instead of segfaults.

### Crash → clean error
- Document with **no usable root element** (DOCTYPE/encoding cases TinyXML silently fails to load) → `XMLException` instead of null-root deref.
- `xs:import`/`xs:include` whose `schemaLocation` can't be loaded (e.g. an `http://` URL) → throws instead of null-schema deref.
- Mixed-content complex type **with an attribute** no longer crashes (null `LuaType` cast guarded).

### Throw → tolerate (parsed, contributes nothing to the model)
- New `IgnoredNode` no-op subclass for `key`/`keyref`/`unique`/`selector`/`field`/`anyAttribute`/`redefine`/`notation`; made transparent in sibling traversal so parent whitelists pass it through.
- `xs:documentation` with embedded markup is collected as text rather than throwing on child elements.
- Group references inside `sequence`/`choice` now resolve.
- Top-level `group`/`attributeGroup` definitions and references resolve — a `parent==DOCUMENT` check wrongly rejected *every* top-level group; corrected to a grandparent check.

Genuinely-unknown tags still throw `InvallidChildXMLElement` — strictness for malformed input is preserved.

### Hardening
- `SplitMarkedFiles` validates `/* FILE: */` marker names against a regex so a template can't write outside `--out-dir`.
- Non-string Lua errors (`error({})`) no longer pass `NULL` to the `LuaException` ctor.
- Removed a stray `dbgPrint` leaking type names to stderr from the `c-xml-expat` template.

## Tests
- 7 positive fixtures (`test/xsd-positive/bug_*.xsd`) — round-trip green across targets.
- 3 negative fixtures (`test/xsd-negative/bug_*.xsd`) — clean throw, exit 4.
- New [`docs/limitations.md`](docs/limitations.md) capability map (linked from README) and a `test/stress/` discovery harness (corpus gitignored).
- **Full suite: 608 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052354&installation_id=141995922&pr_number=64&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F64&signature=076d3eeb712ed5d677b2149d30077e322828d0a172c0390d61f73335384c958e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->