### PR TITLE
Warn on dropped <redefine>; fix stale facet doc; label stress corpus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,10 @@ structurally in `Node::Type_`/`FindXSDElm_`, scoped to the current doc +
 
 **Processors** (`src/Processors/`): `LuaProcessorBase` (BaseProcessor impl, most
 callbacks no-op, holds a `LuaAdapter`); `LuaProcessor` (the real one — builds
-`schema` via the `LuaSchema`/`LuaContent`/`LuaType`/`LuaAttribute` stack; facet
-callbacks are no-ops and `ProcessRestriction` collapses to the base without
-walking facets, hence no validation today); plus `ElementExtracter`,
+`schema` via the `LuaSchema`/`LuaContent`/`LuaType`/`LuaAttribute` stack; the
+facet callbacks record onto `facets_` and `ProcessRestriction` calls
+`walkFacets_`, so facets propagate to the leaf type and are enforced in the
+generated unmarshallers); plus `ElementExtracter`,
 `SimpleTypeExtracter`, `RestrictionVerify` passes.
 
 **Template engine** (`src/TemplateEngine/*.lua`): literal text with embedded

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Run the gtest binary directly (project convention — not ctest):
 The round-trip tests shell out to each target's toolchain (cc, python3, mvn/java,
 node/tsc) and **skip** cleanly when a toolchain is absent.
 
+`test/stress/` is a separate **discovery** tool, not a CI gate. It runs
+`python3 test/stress/run_stress.py` over a corpus of real-world schemas
+(xhtml, wsdl, soap, kml, …) and reports only whether each parses across the
+targets — it does **not** compile or run the generated code, and a failure
+there does not fail the build.
+
 #### Installing / Uninstalling ####
 ```
    sudo cmake --install build --config Release            # uses CMAKE_INSTALL_PREFIX

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -21,6 +21,7 @@
  *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <iostream>
 #include <memory>
 #include <string.h>
 #include <boost/algorithm/string/predicate.hpp>
@@ -252,7 +253,7 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 	   Scoped whitelist — genuinely-unknown tags still throw below. */
 	static const char* const kIgnoredTags[] = {
 		"key", "keyref", "unique", "selector", "field",
-		"anyAttribute", "redefine", "notation",
+		"anyAttribute", "notation",
 	};
 	const std::string elementName = stripPrefix_(pElm->ValueStr());
 	for (const auto& rEntry : kTable) {
@@ -262,6 +263,17 @@ Node::ConstructNode_(const TiXmlElement* pElm, const Parser& rParser) const {
 	for (const char* pTag : kIgnoredTags) {
 		if (boost::iequals(std::string(pTag), elementName))
 			return new IgnoredNode(*pElm, rParser);
+	}
+	/* redefine is accepted (no throw) but its redefinitions are dropped, so
+	   generated code may be silently incomplete — warn once per process. */
+	if (boost::iequals(std::string("redefine"), elementName)) {
+		static bool bWarned = false;
+		if (!bWarned) {
+			bWarned = true;
+			std::cerr << "warning: <redefine> is ignored; its redefinitions "
+			             "are dropped, generated code may be incomplete\n";
+		}
+		return new IgnoredNode(*pElm, rParser);
 	}
 	throw XMLException(*pElm, XMLException::InvallidChildXMLElement);
 	return NULL;


### PR DESCRIPTION
Follow-up to #64, addressing three credibility gaps surfaced while reviewing the
parser-robustness work.

## Changes
- **`<redefine>` now warns instead of silently dropping.** #64 registered
  `redefine` as a silent `IgnoredNode`, so its redefinitions were dropped with
  no signal and generated code could be silently incomplete. It now emits a
  one-time stderr warning and still parses to a no-op `IgnoredNode` (no throw,
  exit stays clean).
- **Corrected a stale claim in `CLAUDE.md`.** It described `LuaProcessor` facet
  callbacks as no-ops with "no validation today" — the opposite of reality:
  `ProcessRestriction` calls `walkFacets_`, facets propagate to the leaf type,
  and the generated unmarshallers enforce them. Rewrote the note to match.
- **Labeled the stress corpus in `README.md`.** `test/stress/` is a parse-only
  discovery tool, not a CI gate — it doesn't compile or run generated code.
  Said so, so "handles real-world schemas" isn't read as "generates correct
  code for them."

## Verification
- Build green; full Python SAX round-trip suite (68 tests) passes, plus the
  golden and negative corpus gtests.
- End-to-end: a schema containing `<xs:redefine>` prints the warning exactly
  once and still generates; a schema without it prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785053693&installation_id=141995922&pr_number=65&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F65&signature=f391eb4b768f76546deda2966aa1702bc70c77db436cf92fe882dd9295a8687d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->