### PR TITLE
Fix false-positive cycle on shared-base extension (WSDL); DOM driver name clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ All notable changes to xsd-tools are documented here. The format is based on
   emit Python 3). Closes #33.
 
 ### Fixed
+- A type extension whose content contains an element whose own type derives
+  from the **same base** (e.g. WSDL's `tDefinitions` extends
+  `tExtensibleDocumented` and contains a `types` element of type `tTypes`,
+  which also extends it) is no longer mis-reported as a `CyclicTypeDefinition`.
+  The derivation-cycle guard now scopes to the base-resolution chain only, not
+  the extension's content. WSDL and similar real-world schemas now generate.
+- The `c-xml-expat-dom` round-trip test driver no longer collides with a
+  schema that declares an element named `doc`: its sample-document variable was
+  hard-coded as `xml_doc`, clashing with the generated `xml_doc` type.
 - Same-named child elements of different types no longer collapse into a
   single generated struct/class. Structurally-distinct types that share a
   local name are disambiguated (`id`, `id1`, …) while identically-structured

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -408,8 +408,13 @@ LuaProcessor::ProcessExtension(const XSD::Elements::Extension* pNode) {
 	if (pBaseKey && 0 != activePath_->count(pBaseKey))
 		throw XSD::XMLException(pNode->GetXMLElm(),
 			XSD::XMLException::CyclicTypeDefinition);
-	PathMark mark(*activePath_, pBaseKey);
-	parseType_(*pBase);
+	/* Mark only while resolving the base derivation chain. The extension's own
+	   content (ParseChildren) may legitimately contain elements whose types
+	   derive from the SAME base (common in WSDL), which is not a cycle. */
+	{
+		PathMark mark(*activePath_, pBaseKey);
+		parseType_(*pBase);
+	}
 	pNode->ParseChildren(*this);
 }
 

--- a/templates/c-xml-expat-dom.template-test
+++ b/templates/c-xml-expat-dom.template-test
@@ -93,7 +93,7 @@ schema = structNamePass(schema)
 #include <expat.h>
 #include "xml_[@lua return schemaNameStripped()].h"
 /* ------------ */
-const char xml_doc[] = 
+const char kInputXml_[] = 
 	"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
 [@lua
 local out = {}
@@ -107,10 +107,10 @@ return table.concat(out,"\n")..";"
 int main(void) {
   char *pMarshalledDoc;
   xml_typelist *pItr;  
-  xml_typelist * pDoc = xml_unmarshal(xml_doc, strlen(xml_doc), NULL);
+  xml_typelist * pDoc = xml_unmarshal(kInputXml_, strlen(kInputXml_), NULL);
   /* verify marshalling */
   pMarshalledDoc = xml_marshal(pDoc, NULL);
-  assert(!strcmp(xml_doc, pMarshalledDoc));
+  assert(!strcmp(kInputXml_, pMarshalledDoc));
   /* clean up */
   xml_destroy(&pDoc, NULL);  
   free(pMarshalledDoc);

--- a/templates/c-xml-expat-dom.template-test
+++ b/templates/c-xml-expat-dom.template-test
@@ -93,7 +93,7 @@ schema = structNamePass(schema)
 #include <expat.h>
 #include "xml_[@lua return schemaNameStripped()].h"
 /* ------------ */
-const char kInputXml_[] = 
+static const char kInputXml_[] =
 	"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
 [@lua
 local out = {}

--- a/test/xsd-positive/shared_base_extension.xsd
+++ b/test/xsd-positive/shared_base_extension.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="Base">
+    <xs:sequence><xs:element name="doc" type="xs:string" minOccurs="0"/></xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Inner">
+    <xs:complexContent><xs:extension base="Base"/></xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Outer">
+    <xs:complexContent><xs:extension base="Base">
+      <xs:sequence><xs:element name="inner" type="Inner"/></xs:sequence>
+    </xs:extension></xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="Outer"/>
+</xs:schema>


### PR DESCRIPTION
Follow-up to #66. Testing the new recursive-type support against the large
real-world schemas in `test/stress/corpus/` (WSDL, SOAP, XHTML, …) surfaced two
bugs.

## 1. Shared-base extension wrongly rejected as a cycle (hit WSDL)
The derivation-cycle guard in `ProcessExtension` held the base-type mark across
`ParseChildren`, so a type that extends `Base` **and** whose content contains an
element whose type *also* extends `Base` was reported as `CyclicTypeDefinition`.
This is exactly WSDL's shape: `tDefinitions` extends `tExtensibleDocumented` and
contains a `types` element of type `tTypes`, which also extends it.

Fix: scope the mark to the base-resolution chain only — the extension's own
content is not part of the derivation chain. Genuine derivation cycles
(`A extends B extends A`) are still rejected. **WSDL now generates** (647 lines).
Added `test/xsd-positive/shared_base_extension.xsd` (a minimal repro) as a
round-trip regression — passes on every target.

## 2. `c-xml-expat-dom` round-trip driver name clash
The DOM test driver hard-coded its sample-document variable as `xml_doc`, which
collides with the generated `xml_doc` type whenever a schema declares an element
named `doc` (a compile error in the driver, breaking that target's round-trip).
Renamed to `kInputXml_`.

## Verification
- Full test suite green (TS round-trips skip without node/tsc).
- 200-deep self-recursion and 3-way mutual recursion (A→B→C→A) round-trip.
- Golden corpus byte-identical; `shared_base_extension` round-trips on all
  targets including the previously-failing DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785083626&installation_id=141995922&pr_number=67&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F67&signature=a78ba738c64013d70197d0655a06cc3721c8de41a26da02e102e740b0b5ce3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->