### PR TITLE
Fix 12 high-severity bugs found by codebase scan

### DIFF
--- a/src/Processors/LuaAdapter.cpp
+++ b/src/Processors/LuaAdapter.cpp
@@ -54,6 +54,34 @@ LuaFacets::addToList(const std::string& rName, const std::string& rValue) {
 		std::make_pair(rName, std::vector<std::string>(1, rValue)));
 }
 
+void
+LuaFacets::mergeBase(const LuaFacets& rBase) {
+	for (size_t i = 0; i < rBase.scalars.size(); ++i) {
+		bool present = false;
+		for (size_t j = 0; !present && j < scalars.size(); ++j)
+			present = (scalars[j].first == rBase.scalars[i].first);
+		if (!present)
+			scalars.push_back(rBase.scalars[i]);
+	}
+	for (size_t i = 0; i < rBase.lists.size(); ++i) {
+		const std::string& rName = rBase.lists[i].first;
+		if (rName == "pattern") {
+			/* pattern facets from every derivation step apply (ANDed) */
+			const std::vector<std::string>& rVals = rBase.lists[i].second;
+			for (size_t j = 0; j < rVals.size(); ++j)
+				addToList(rName, rVals[j]);
+			continue;
+		}
+		/* enumeration (and other value sets): the derived level's set is a
+		   subset that replaces the base's, so keep it only when absent */
+		bool present = false;
+		for (size_t j = 0; !present && j < lists.size(); ++j)
+			present = (lists[j].first == rName);
+		if (!present)
+			lists.push_back(rBase.lists[i]);
+	}
+}
+
 /* helper functions */
 static void luaStackDump_(lua_State * pLuaState);
 #if (DEBUG_LUASTACK)

--- a/src/Processors/LuaAdapter.hpp
+++ b/src/Processors/LuaAdapter.hpp
@@ -49,6 +49,10 @@ namespace Processors {
 			scalars.push_back(std::make_pair(rName, rValue));
 		}
 		void addToList(const std::string& rName, const std::string& rValue);
+		/* merge a base derivation level under this (derived) one: derived
+		   scalars win, a derived enumeration replaces the base's, and
+		   patterns accumulate (steps are ANDed in XSD) */
+		void mergeBase(const LuaFacets& rBase);
 	};
 
 	/* forward declare classes */

--- a/src/Processors/LuaProcessor.cpp
+++ b/src/Processors/LuaProcessor.cpp
@@ -23,7 +23,11 @@
 
 #include <sstream>
 #include <memory>
+#include <iomanip>
+#include <limits>
 #include <assert.h>
+#include <math.h>
+#include <stdlib.h>
 #include "./src/XSDParser/Parser.hpp"
 #include "./src/XSDParser/Elements/Node.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"
@@ -144,8 +148,16 @@ LuaProcessor::ProcessSchema(const XSD::Elements::Schema* pNode) {
 
 /* virtual */ void
 LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
+	processElement_(pNode, pNode);
+}
+
+/* Occurs always come from pOccursSite: a ref= element carries them on the
+   referencing site, never on the global element it resolves to. */
+void
+LuaProcessor::processElement_(	const XSD::Elements::Element* pNode,
+								const XSD::Elements::Element* pOccursSite) {
 	/* don't process element if it can't occur */
-	if (pNode->HasMaxOccurs() && (0 == pNode->MaxOccurs()))
+	if (pOccursSite->HasMaxOccurs() && (0 == pOccursSite->MaxOccurs()))
 		return;
 	/* output the element */
 	if (!pNode->HasRef()) {
@@ -158,11 +170,13 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 			LuaType * pLuaType = dynamic_cast<LuaType*>(luaAdapter_());
 			LuaProcessor processor(pLuaType->Content());
 			processor.activePath_ = activePath_;
-			processor.ProcessElement(pNode);
+			processor.processElement_(pNode, pOccursSite);
 		} else {
 			/* Default min/maxOccurs is 1 */
-			int maxOccurs = pNode->HasMaxOccurs() ?	pNode->MaxOccurs() : 1;
-			int minOccurs = pNode->HasMinOccurs() ?	pNode->MinOccurs() : 1;
+			int maxOccurs = pOccursSite->HasMaxOccurs() ?
+				pOccursSite->MaxOccurs() : 1;
+			int minOccurs = pOccursSite->HasMinOccurs() ?
+				pOccursSite->MinOccurs() : 1;
 			LuaType * pLuaType =
 				pLuaContent->Type(pNode->Name(), maxOccurs, minOccurs);
 			LuaProcessor luaPrcssr(pLuaType);
@@ -190,7 +204,7 @@ LuaProcessor::ProcessElement(const XSD::Elements::Element* pNode) {
 		}
 	} else {
 		unique_ptr<XSD::Elements::Element> pRefElm(pNode->RefElement());
-		ProcessElement(pRefElm.get());
+		processElement_(pRefElm.get(), pOccursSite);
 	}
 }
 
@@ -222,9 +236,13 @@ LuaProcessor::ProcessRestriction(const XSD::Elements::Restriction* pNode ) {
 }
 
 /* Dispatch each facet child of a simpleType restriction to this processor,
-   so the ProcessXxx facet overrides record their values. */
+   so the ProcessXxx facet overrides record their values. facets_ already
+   holds the more-derived levels' facets; record this level aside and merge
+   it underneath so derived values keep precedence. */
 void
 LuaProcessor::walkFacets_(const XSD::Elements::Node* pNode) {
+	LuaFacets derived = facets_;
+	facets_.clear();
 	pNode->eachChild_([this](const XSD::Elements::Node& rChild) {
 		if (XSD_ISELEMENT(&rChild, XSD::Elements::MinExclusive) ||
 			XSD_ISELEMENT(&rChild, XSD::Elements::MaxExclusive) ||
@@ -241,6 +259,8 @@ LuaProcessor::walkFacets_(const XSD::Elements::Node* pNode) {
 			rChild.ParseElement(*this);
 		}
 	});
+	derived.mergeBase(facets_);
+	facets_ = derived;
 }
 
 /* virtual */ void
@@ -443,6 +463,25 @@ template <typename T>
 static string numStr_(T val) {
 	ostringstream ss;
 	ss << val;
+	return ss.str();
+}
+
+/* Long-double bounds must not lose digits to the default precision (6).
+   Integral values print in plain integer form; fractional ones use the
+   fewest digits that round-trip (trailing zeros still dropped). */
+static string numStr_(long double val) {
+	ostringstream ss;
+	if (val == floorl(val)) {
+		ss << fixed << setprecision(0) << val;
+		return ss.str();
+	}
+	const int maxPrec = numeric_limits<long double>::max_digits10;
+	for (int prec = 6; prec <= maxPrec; ++prec) {
+		ss.str("");
+		ss << setprecision(prec) << val;
+		if (val == strtold(ss.str().c_str(), NULL))
+			break;
+	}
 	return ss.str();
 }
 

--- a/src/Processors/LuaProcessor.hpp
+++ b/src/Processors/LuaProcessor.hpp
@@ -71,6 +71,10 @@ namespace Processors {
 		virtual void parseType_(const XSD::Types::BaseType& rXSDType);
 	private:
 		LuaProcessor();
+		/* process an element, taking occurs from pOccursSite (the
+		 * referencing site for ref= elements, pNode otherwise) */
+		void processElement_(const XSD::Elements::Element* pNode,
+							 const XSD::Elements::Element* pOccursSite);
 		/* dispatch a restriction's facet children to this processor */
 		void walkFacets_(const XSD::Elements::Node* pNode);
 		/* accumulate an attribute's restriction facets onto facets_ */

--- a/src/TemplateEngine/parser.lua
+++ b/src/TemplateEngine/parser.lua
@@ -67,23 +67,80 @@ function parser:new(obj)
 	return obj
 end
 
--- Fold the template into a stringBuffer, recursing over byte offsets: find the
--- next [@lua marker, balance-match its block from there (%b[] anchored on the
--- marker, so a literal '[' just before it -- e.g. arr[[@lua..]] -- is left
--- intact), and substitute it; a backslash before the marker emits it verbatim.
--- Threading the offset (not the remainder) keeps it O(template length).
+-- Offset of the ']' closing the block opened by the '[' at `s`, or nil if
+-- unterminated. Tracks Lua lexical state so brackets inside quoted strings,
+-- long strings/comments and line comments don't affect bracket depth.
+local function blockEnd_(str, s)
+	local n = #str
+	local i = s + 1
+	local depth = 1
+	while i <= n do
+		local c = str:sub(i, i)
+		if c == '"' or c == "'" then
+			i = i + 1
+			while i <= n and str:sub(i, i) ~= c do
+				i = i + (str:sub(i, i) == '\\' and 2 or 1)
+			end
+			if i > n then return nil end
+		elseif c == '[' then
+			local eq = str:match('^%[(=*)%[', i)
+			if eq then
+				local _, e = str:find(']' .. eq .. ']', i + #eq + 2, true)
+				if not e then return nil end
+				i = e
+			else
+				depth = depth + 1
+			end
+		elseif c == '-' and str:sub(i + 1, i + 1) == '-' then
+			local eq = str:match('^%[(=*)%[', i + 2)
+			if eq then
+				local _, e = str:find(']' .. eq .. ']', i + #eq + 4, true)
+				if not e then return nil end
+				i = e
+			else
+				i = (str:find('\n', i + 2, true) or n + 1) - 1
+			end
+		elseif c == ']' then
+			depth = depth - 1
+			if depth == 0 then return i end
+		end
+		i = i + 1
+	end
+	return nil
+end
+
+local function lineOf_(str, pos)
+	local _, nl = str:sub(1, pos):gsub('\n', '')
+	return nl + 1
+end
+
+-- Fold the template into a stringBuffer, recursing over byte offsets: find
+-- the next [@lua marker, lex forward to its matching close bracket (anchored
+-- on the marker, so a literal '[' just before it -- e.g. arr[[@lua..]] -- is
+-- left intact), and substitute it; a backslash before the marker emits it
+-- verbatim. A block that fails to load or run, or never closes, aborts the
+-- fold so no error text leaks into the output. Threading the offset (not the
+-- remainder) keeps it O(template length).
 function parser:parse(str)
 	local function scan(pos, out)
 		local s = str:find("[@lua", pos, true)
 		if not s then return out:append(str:sub(pos)) end
 		out:append(str:sub(pos, s - 1))
-		local _, e = str:find("%b[]", s)
+		local e = blockEnd_(str, s)
+		if not e then
+			error(("unterminated [@lua block at line %d")
+				:format(lineOf_(str, s)), 0)
+		end
 		local blk = str:sub(s, e)
 		if str:sub(s - 1, s - 1) == '\\' then
 			out:append(blk)
 		else
-			local _, msg = self.prvtEnv:invoke(blk:match("^%[@lua(.*)%]$"))
-			out:append(msg or "")
+			local ok, res = self.prvtEnv:invoke(blk:match("^%[@lua(.*)%]$"))
+			if not ok then
+				error(("template error at line %d: %s")
+					:format(lineOf_(str, s), tostring(res)), 0)
+			end
+			out:append(res or "")
 		end
 		return scan(e + 1, out)
 	end

--- a/src/TemplateEngine/templateEngine.lua
+++ b/src/TemplateEngine/templateEngine.lua
@@ -22,7 +22,11 @@
 --require 'src/Processors/stringbuffer'
 
 local loadTemplate = function(fileName)
-	local file = io.open(fileName, "r")
+	local file, err = io.open(fileName, "r")
+	if not file then
+		error("cannot open template '" .. fileName .. "': "
+			.. tostring(err), 0)
+	end
 	local template = file:read("*all")
 	file:close()
 	return template

--- a/src/XSDParser/Elements/All.cpp
+++ b/src/XSDParser/Elements/All.cpp
@@ -45,14 +45,14 @@ All::All(const All& cpy)
 
 void
 All::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
-	std::unique_ptr<Node> pNode(Node::FirstChild());
-	if (NULL != pNode.get()) {
-		if (XSD_ISELEMENT(pNode.get(), Element) ||
-			XSD_ISELEMENT(pNode.get(), Annotation))
-			pNode->ParseElement(rProcessor);
-		else
-			throw XMLException(pNode->GetXMLElm(), XMLException::InvallidChildXMLElement);
-	}
+	/* process children */
+	eachChild_([&rProcessor](const Node& rNode) {
+		if (XSD_ISELEMENT(&rNode, Element) ||
+			XSD_ISELEMENT(&rNode, Annotation)) {
+			rNode.ParseElement(rProcessor);
+		} else
+			throw XMLException(rNode.GetXMLElm(), XMLException::InvallidChildXMLElement);
+	});
 }
 
 void

--- a/src/XSDParser/Elements/Attribute.cpp
+++ b/src/XSDParser/Elements/Attribute.cpp
@@ -50,7 +50,7 @@ Attribute::ParseChildren(BaseProcessor& rProcessor) const noexcept(false) {
 	eachChild_([&rProcessor](const Node& rNode) {
 		if (XSD_ISELEMENT(&rNode, SimpleType) ||
 			XSD_ISELEMENT(&rNode, Annotation)) {
-			rProcessor.ProcessSimpleType(static_cast<const SimpleType*>(&rNode));
+			rNode.ParseElement(rProcessor);
 		} else
 			throw XMLException(rNode.GetXMLElm(), XMLException::InvallidChildXMLElement);
 	});

--- a/src/XSDParser/Elements/Element.cpp
+++ b/src/XSDParser/Elements/Element.cpp
@@ -88,7 +88,8 @@ Element::ParseElement(BaseProcessor& rProcessor) const noexcept(false) {
 		if (pRefElm->HasMaxOccurs() && pRefElm->IsRootNode())
 			throw XMLException(pRefElm->GetXMLElm(), XMLException::InvalidAttribute);
 		/* if an element is a substitution group verify types */
-		if (pRefElm->HasSubstitutionGroup() && !VerifySubstitutionGroup()) {
+		if (pRefElm->HasSubstitutionGroup() &&
+			!pRefElm->VerifySubstitutionGroup()) {
 			throw XMLException(Node::GetXMLElm(), XMLException::SubstitutionGroupTypeMismatch);
 		}
 	}

--- a/src/XSDParser/Elements/Node.cpp
+++ b/src/XSDParser/Elements/Node.cpp
@@ -292,13 +292,19 @@ Node::FindXSDElm_(const XsdQName& rName, const char* pTypeName) const noexcept(f
 			: NULL;
 	/* search all included documents (same-namespace merge) */
 	if (!pElm) {
-		const TiXmlElement* pIncludElm = pSchemaRoot->GetXMLElm().FirstChildElement(XSD::Elements::Include::XSDTag());
-		for ( ; pIncludElm; pIncludElm = pIncludElm->NextSiblingElement(XSD::Elements::Include::XSDTag()) ) {
+		std::string includeTag =
+			QualifyElementName(XSD::Elements::Include::XSDTag());
+		const TiXmlElement* pIncludElm =
+			pSchemaRoot->GetXMLElm().FirstChildElement(includeTag.c_str());
+		for ( ; pIncludElm;
+		      pIncludElm = pIncludElm->NextSiblingElement(includeTag.c_str()) ) {
 			std::unique_ptr<Include> pNode(static_cast<Include*>(ConstructNode_(pIncludElm, rParser_)));
 			const Schema* pSchema = pNode->QuerySchema();
 			if (pSchema->TargetNamespace() != rName.ns)
 				continue;
-			if (NULL != (pElm = pSchema->FindChildXMLElement_(elementName.c_str(), "name", pLocal))) {
+			/* qualify the type tag against the included doc's own prefix */
+			std::string inclTypeTag = pSchema->QualifyElementName(pTypeName);
+			if (NULL != (pElm = pSchema->FindChildXMLElement_(inclTypeTag.c_str(), "name", pLocal))) {
 				pRetNode = ConstructNode_(pElm, pSchema->rParser_);
 				break;
 			}

--- a/src/XSDParser/Parser.cpp
+++ b/src/XSDParser/Parser.cpp
@@ -21,6 +21,7 @@
  *  along with xsd-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <memory>
 #include "./src/XSDParser/Parser.hpp"
 #include "./src/XSDParser/Elements/Schema.hpp"
 #define PROTO_FILE	"file://"
@@ -71,31 +72,28 @@ Parser::Parse(const std::string& rUri) const noexcept(false) {
 			throw XMLException(*pRec->pDocument_);
 		return new Elements::Schema(*(pRec->pDocument_->RootElement()),
 			*this, rUri);
-	} else {
-		docLst_.push_back(new DocumentRecord(new TiXmlDocument(), rUri));
-		TiXmlDocument * pDoc = docLst_.back()->pDocument_;
-		pDoc->SetTabSize(4);
-		/* parse protocol portion. LoadFile can return true yet leave no root
-		   element (TinyXML silently mis-parses some DOCTYPE/encoding cases);
-		   guard RootElement() so a malformed document throws instead of binding
-		   a null reference into Schema and segfaulting later. */
-		if (0 == rUri.find(PROTO_FILE)) {
-			std::string path = rUri.substr(sizeof(PROTO_FILE) - 1);
-			if( !pDoc->LoadFile(path, TIXML_ENCODING_UTF8)
-			    || NULL == pDoc->RootElement() ) {
-				throw XMLException(*pDoc);
-			}
-			return new Elements::Schema(*pDoc->RootElement(), *this, rUri);
-		} else if (std::string::npos == rUri.find("://")) {
-			/* if no protocol specified then assume it is a local file */
-			if( !pDoc->LoadFile(rUri, TIXML_ENCODING_UTF8)
-			    || NULL == pDoc->RootElement() ) {
-				throw XMLException(*pDoc);
-			}
-			return new Elements::Schema(*pDoc->RootElement(), *this, rUri);
-		}
 	}
-	return NULL;
+	/* only file:// or bare local paths are loadable; reject any other
+	   protocol before touching the cache so a retry reports the same error */
+	std::string path(rUri);
+	if (0 == rUri.find(PROTO_FILE))
+		path = rUri.substr(sizeof(PROTO_FILE) - 1);
+	else if (std::string::npos != rUri.find("://"))
+		throw XMLException(TiXmlDocument(),
+			XMLException::ProtocolNotSupported);
+	std::unique_ptr<TiXmlDocument> pDoc(new TiXmlDocument());
+	pDoc->SetTabSize(4);
+	/* LoadFile can return true yet leave no root element (TinyXML silently
+	   mis-parses some DOCTYPE/encoding cases); guard RootElement() so a
+	   malformed document throws instead of binding a null reference into
+	   Schema and segfaulting later. Cache only successfully loaded docs. */
+	if( !pDoc->LoadFile(path, TIXML_ENCODING_UTF8)
+	    || NULL == pDoc->RootElement() ) {
+		throw XMLException(*pDoc);
+	}
+	docLst_.push_back(new DocumentRecord(pDoc.release(), rUri));
+	return new Elements::Schema(
+		*docLst_.back()->pDocument_->RootElement(), *this, rUri);
 }
 
 const Types::TypesDB&

--- a/src/XSDParser/Types.hpp
+++ b/src/XSDParser/Types.hpp
@@ -38,7 +38,10 @@
       return new TYPE();						\
     }									\
     virtual bool isTypeRelated(const BaseType* pType) const {		\
-      return (NULL != dynamic_cast<const TYPE*>(pType));		\
+      return pType->isBaseTypeOf(this);					\
+    }									\
+    virtual bool isBaseTypeOf(const BaseType* pOther) const {		\
+      return (NULL != dynamic_cast<const TYPE*>(pOther));		\
     }									\
     virtual const char* Name() const {					\
       return #NAME;							\
@@ -60,7 +63,15 @@ namespace XSD {
     struct BaseType {
       virtual ~BaseType() {}
       virtual BaseType* clone() const = 0;
-      virtual bool isTypeRelated(const BaseType*) const = 0;
+      /* true when this type equals or derives from *pType */
+      virtual bool isTypeRelated(const BaseType* pType) const = 0;
+      /* Double-dispatch helper for isTypeRelated: true when *pOther equals
+       * or derives from this type's class. Non-pure so the wrapper and
+       * processor types keep their bespoke isTypeRelated; nothing derives
+       * from those, hence the false default. */
+      virtual bool isBaseTypeOf(const BaseType* pOther) const {
+        return false;
+      }
       virtual const char* Name() const = 0;
     };
     XSD_VTYPEDEF(AnySimpleType,BaseType, anySimpleType);

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -96,6 +96,10 @@ homeDir_() noexcept {
 	const char* home = getenv("USERPROFILE");
 	return home ? string(home) : string();
 #else
+	/* honor $HOME (overridable, e.g. in tests); fall back to passwd */
+	const char* home = getenv("HOME");
+	if (home && *home)
+		return string(home);
 	struct passwd* pw = getpwuid(getuid());
 	return pw ? string(pw->pw_dir) : string();
 #endif
@@ -150,7 +154,7 @@ Resource::GetTemplatePath(const std::string& templateName) noexcept(false) {
 	string homeDir(homeDir_());
 	if (!homeDir.empty()) {
 		string homeFilePath(homeDir);
-		homeFilePath += "/" + gscHOMEPATH.substr(1) + templateName;
+		homeFilePath += gscHOMEPATH.substr(1) + "/" + templateName;
 		if (readable_(homeFilePath))
 			return homeFilePath;
 	}
@@ -186,7 +190,7 @@ Resource::TemplatesDir() noexcept {
 		return string(val);
 	string homeDir(homeDir_());
 	if (!homeDir.empty()) {
-		homeDir += "/" + gscHOMEPATH.substr(1);
+		homeDir += gscHOMEPATH.substr(1);
 		if (readable_(homeDir))
 			return homeDir;
 	}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,6 +141,7 @@ endif()
 # every target's code generation; the round-trips run on the POSIX runners.
 if(WIN32)
   add_executable(xsdb-test
+    elementTests.cpp
     facetTests.cpp
     parserTests.cpp
     resourceTests.cpp)
@@ -180,6 +181,7 @@ else()
   add_executable(xsdb-test
     roundtrip_util.cpp
     generateTests.cpp
+    elementTests.cpp
     facetTests.cpp
     parserTests.cpp
     resourceTests.cpp

--- a/test/elementTests.cpp
+++ b/test/elementTests.cpp
@@ -1,0 +1,164 @@
+/*
+ * elementTests.cpp — regression tests for the XSD element/type model:
+ * xs:all child iteration, substitution-group verification (direct and via
+ * ref), builtin type-derivation direction, and xs:attribute child dispatch.
+ * Fixtures live under xsdparse/ (not the auto-globbed corpora).
+ *
+ *  This file is part of xsd-tools.
+ */
+#include <memory>
+#include <sstream>
+#include <string>
+#include <gtest/gtest.h>
+#include "src/xsdtools.hpp"
+#include "src/XSDParser/Parser.hpp"
+#include "src/XSDParser/Exception.hpp"
+#include "src/XSDParser/ProcessorBase.hpp"
+#include "src/XSDParser/Elements/Node.hpp"
+#include "src/XSDParser/Elements/Schema.hpp"
+#include "src/XSDParser/Elements/Element.hpp"
+#include "src/XSDParser/Elements/ComplexType.hpp"
+#include "src/XSDParser/Elements/Sequence.hpp"
+#include "src/XSDParser/Elements/All.hpp"
+#include "src/XSDParser/Elements/Attribute.hpp"
+
+namespace {
+	std::string gen(const std::string& xsd) {
+		std::ostringstream out;
+		XsdTools::Generate(TEMPLATES_DIR "/test",
+		                   std::string(XSDPARSE_DIR "/") + xsd, out);
+		return out.str();
+	}
+	bool has(const std::string& hay, const std::string& needle) {
+		return hay.find(needle) != std::string::npos;
+	}
+
+	/* Minimal BaseProcessor: recurses containers, counts the leaf callbacks
+	 * whose dispatch the tests assert on; everything else is a no-op. */
+	#define NOOP_CB(METHOD, TYPE) \
+		virtual void METHOD(const XSD::Elements::TYPE*) {}
+	struct CountingProcessor : public XSD::BaseProcessor {
+		int simpleTypes_;
+		int annotations_;
+		int elements_;
+		CountingProcessor()
+			: simpleTypes_(0), annotations_(0), elements_(0) {}
+		virtual void ProcessSchema(const XSD::Elements::Schema* pNode) {
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessElement(const XSD::Elements::Element* pNode) {
+			++elements_;
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessComplexType(
+			const XSD::Elements::ComplexType* pNode) {
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessSequence(const XSD::Elements::Sequence* pNode) {
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessAll(const XSD::Elements::All* pNode) {
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessAttribute(const XSD::Elements::Attribute* pNode) {
+			pNode->ParseChildren(*this);
+		}
+		virtual void ProcessSimpleType(const XSD::Elements::SimpleType*) {
+			++simpleTypes_;
+		}
+		virtual void ProcessAnnotation(const XSD::Elements::Annotation*) {
+			++annotations_;
+		}
+		NOOP_CB(ProcessUnion, Union)
+		NOOP_CB(ProcessRestriction, Restriction)
+		NOOP_CB(ProcessList, List)
+		NOOP_CB(ProcessChoice, Choice)
+		NOOP_CB(ProcessGroup, Group)
+		NOOP_CB(ProcessAny, Any)
+		NOOP_CB(ProcessComplexContent, ComplexContent)
+		NOOP_CB(ProcessExtension, Extension)
+		NOOP_CB(ProcessSimpleContent, SimpleContent)
+		NOOP_CB(ProcessMinExclusive, MinExclusive)
+		NOOP_CB(ProcessMaxExclusive, MaxExclusive)
+		NOOP_CB(ProcessMinInclusive, MinInclusive)
+		NOOP_CB(ProcessMaxInclusive, MaxInclusive)
+		NOOP_CB(ProcessMinLength, MinLength)
+		NOOP_CB(ProcessMaxLength, MaxLength)
+		NOOP_CB(ProcessLength, Length)
+		NOOP_CB(ProcessEnumeration, Enumeration)
+		NOOP_CB(ProcessFractionDigits, FractionDigits)
+		NOOP_CB(ProcessPattern, Pattern)
+		NOOP_CB(ProcessTotalDigits, TotalDigits)
+		NOOP_CB(ProcessWhiteSpace, WhiteSpace)
+		NOOP_CB(ProcessAttributeGroup, AttributeGroup)
+		NOOP_CB(ProcessInclude, Include)
+		NOOP_CB(ProcessDocumentation, Documentation)
+		NOOP_CB(ProcessAppInfo, AppInfo)
+	};
+	#undef NOOP_CB
+}
+
+/* xs:all iterates the whole sibling chain: every member is emitted even with
+ * a leading annotation. */
+TEST(All, EmitsEveryMember) {
+	std::string out;
+	ASSERT_NO_THROW(out = gen("allMembers.xsd"));
+	EXPECT_TRUE(has(out, "firstName"));
+	EXPECT_TRUE(has(out, "lastName"));
+	EXPECT_TRUE(has(out, "age"));
+}
+
+/* Model-level check of the same: all three xs:all members reach the
+ * processor. */
+TEST(All, DispatchesEveryMember) {
+	XSD::Parser parser;
+	std::unique_ptr<XSD::Elements::Schema> pRoot(
+		parser.Parse(std::string(XSDPARSE_DIR "/allMembers.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, pRoot.get());
+	CountingProcessor counter;
+	ASSERT_NO_THROW(pRoot->ParseElement(counter));
+	/* person + firstName/lastName/age */
+	EXPECT_EQ(4, counter.elements_);
+	EXPECT_EQ(1, counter.annotations_);
+}
+
+/* A ref to a substitution-group member verifies the referenced element (the
+ * ref site carries no substitutionGroup attribute), and a member whose type
+ * derives from the head's (xs:int under xs:integer, directly or through a
+ * user simpleType) is accepted. */
+TEST(SubstitutionGroup, RefAndDerivedTypesAccepted) {
+	std::string out;
+	EXPECT_NO_THROW(out = gen("substRefValid.xsd"));
+	EXPECT_TRUE(has(out, "member"));
+}
+
+/* The inverse derivation (member typed xs:integer under a head typed xs:int)
+ * is a genuine type mismatch and must be rejected. */
+TEST(SubstitutionGroup, BaseTypedMemberRejected) {
+	try {
+		gen("substRefInvalid.xsd");
+		FAIL() << "expected XMLException";
+	} catch (const XSD::XMLException& e) {
+		EXPECT_EQ((int)XSD::XMLException::SubstitutionGroupTypeMismatch,
+		          e.QueryError().errorId_);
+	}
+}
+
+/* xs:attribute children double-dispatch to their own callbacks: the inline
+ * simpleType reaches ProcessSimpleType exactly once and the annotation
+ * reaches ProcessAnnotation (never ProcessSimpleType via a bogus cast). */
+TEST(Attribute, ChildrenDispatchToOwnCallbacks) {
+	XSD::Parser parser;
+	std::unique_ptr<XSD::Elements::Schema> pRoot(
+		parser.Parse(std::string(XSDPARSE_DIR "/attrAnnotation.xsd")));
+	ASSERT_NE((XSD::Elements::Schema*)NULL, pRoot.get());
+	CountingProcessor counter;
+	ASSERT_NO_THROW(pRoot->ParseElement(counter));
+	EXPECT_EQ(1, counter.simpleTypes_);
+	EXPECT_EQ(1, counter.annotations_);
+}
+
+/* End-to-end: the annotated attribute schema generates cleanly. */
+TEST(Attribute, AnnotatedAttributeGenerates) {
+	EXPECT_NO_THROW(gen("attrAnnotation.xsd"));
+}

--- a/test/facetTests.cpp
+++ b/test/facetTests.cpp
@@ -26,6 +26,8 @@ namespace {
 	/* recursive fixtures live beside the negative corpus but must not be
 	   globbed by it (they are accepted, not rejected) */
 	const std::string RECURSIVE(XSD_NEGATIVE_DIR "/../xsd-recursive/");
+	/* fixtures referenced explicitly (no golden, no round-trip glob) */
+	const std::string PARSE(XSDPARSE_DIR "/");
 }
 
 /* D2b: a 0..255 integer narrows to the smallest fixed-width C type (uint8_t);
@@ -175,6 +177,38 @@ TEST(Attr, CppDispatchUsesHashNotSetAttribute) {
 TEST(Attr, CppDefaultValueInitialized) {
 	const std::string out = gen("cpp-xml-expat", CORPUS + "testA015.xsd");
 	EXPECT_TRUE(has(out, "int32_t a_myAttr = 0;"));
+}
+
+/* Bug: a ref= element's minOccurs/maxOccurs live on the referencing site
+ * (the global element it resolves to legally cannot carry them); the site's
+ * occurs must land in the model. ref_occurs.xsd refs with 0..unbounded. */
+TEST(Bug, RefElementKeepsSiteOccurs) {
+	const std::string out = gen("test", PARSE + "ref_occurs.xsd");
+	EXPECT_TRUE(has(out, "minOccurs = 0"));
+	EXPECT_TRUE(has(out, "maxOccurs = -1"));
+}
+
+/* Bug: a derived restriction's scalar facet must win over the base's (D
+ * restricts B with maxLength=10 where B has maxLength=100 -> 10 applies),
+ * a derived enumeration REPLACES the base's, and pattern facets from every
+ * derivation step accumulate (they are ANDed in XSD). */
+TEST(Bug, DerivedFacetOverridesBase) {
+	const std::string out = gen("test", PARSE + "facet_override.xsd");
+	EXPECT_TRUE(has(out, "maxLength = 10\n"));
+	EXPECT_FALSE(has(out, "maxLength = 100"));
+	EXPECT_TRUE(has(out, "enumeration = { alpha, beta }"));
+	EXPECT_FALSE(has(out, "gamma"));
+	EXPECT_TRUE(has(out, "pattern = { [ab].*, [a-z]+ }"));
+}
+
+/* Bug: numeric facet bounds were rounded to 6 significant digits
+ * (4294967295 -> "4.29497e+09"). Integral bounds print in plain integer
+ * form; fractional ones keep round-trip precision. */
+TEST(Bug, NumericFacetFullPrecision) {
+	const std::string out = gen("test", PARSE + "facet_precision.xsd");
+	EXPECT_TRUE(has(out, "maxInclusive = 4294967295"));
+	EXPECT_FALSE(has(out, "e+09"));
+	EXPECT_TRUE(has(out, "minInclusive = 2.5"));
 }
 
 /* Java centralizes attribute unmarshalling in Element.unmarshal via a native

--- a/test/generateTests.cpp
+++ b/test/generateTests.cpp
@@ -4,12 +4,16 @@
  *
  *  This file is part of xsd-tools.
  */
+#include <cstdio>
+#include <cstdlib>
 #include <dirent.h>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <unistd.h>
 #include <vector>
 #include <gtest/gtest.h>
+#include "src/luaScriptAdapter.hpp"
 #include "src/xsdtools.hpp"
 #include "src/XSDParser/Exception.hpp"
 
@@ -36,6 +40,50 @@ namespace {
 		}
 		closedir(d);
 		return out;
+	}
+
+	/* One-off on-disk template for the engine error/scanner tests; the
+	 * engine only loads templates from files. */
+	class TempTemplate {
+	public:
+		explicit TempTemplate(const std::string& text) {
+			char tmpl[] = "/tmp/xsdb-gen-XXXXXX";
+			const char* d = mkdtemp(tmpl);
+			dir_ = d ? d : "";
+			path_ = dir_ + "/tpl";
+			std::ofstream f(path_.c_str(), std::ios::binary);
+			f << text;
+		}
+		~TempTemplate() {
+			remove(path_.c_str());
+			rmdir(dir_.c_str());
+		}
+		const std::string& Path() const { return path_; }
+	private:
+		std::string dir_;
+		std::string path_;
+	};
+
+	/* Any small valid schema works: these templates never read `schema`. */
+	const char* const kAnyXsd = XSD_CORPUS_DIR "/testA001.xsd";
+
+	std::string generateWith(const std::string& templateText) {
+		TempTemplate tpl(templateText);
+		std::ostringstream out;
+		XsdTools::Generate(tpl.Path(), kAnyXsd, out);
+		return out.str();
+	}
+
+	std::string generateError(const std::string& templateText) {
+		TempTemplate tpl(templateText);
+		std::ostringstream out;
+		try {
+			XsdTools::Generate(tpl.Path(), kAnyXsd, out);
+		} catch (const Core::LuaException& e) {
+			return e.what();
+		}
+		ADD_FAILURE() << "generation succeeded; output: " << out.str();
+		return "";
 	}
 }
 
@@ -69,4 +117,51 @@ TEST(Generate, RejectsNegativeCorpus) {
 		EXPECT_THROW(XsdTools::Generate(TEMPLATES_DIR "/test", xsd, out),
 		             XSD::XMLException) << xsds[i];
 	}
+}
+
+/* A block that raises at runtime must abort generation, not have its error
+ * message pasted into the output. */
+TEST(Generate, BlockRuntimeErrorAborts) {
+	std::string msg = generateError("A[@lua return nil .. 1]B");
+	EXPECT_NE(std::string::npos, msg.find("concatenate")) << msg;
+	EXPECT_NE(std::string::npos, msg.find("line 1")) << msg;
+}
+
+/* Same for a block that fails to even compile. */
+TEST(Generate, BlockLoadErrorAborts) {
+	std::string msg = generateError("\n\nA[@lua return ( ]B");
+	EXPECT_NE(std::string::npos, msg.find("line 3")) << msg;
+}
+
+/* include of a nonexistent template must fail naming the missing path. */
+TEST(Generate, MissingIncludeAborts) {
+	std::string msg =
+		generateError("[@lua return include 'no-such-template']");
+	EXPECT_NE(std::string::npos, msg.find("no-such-template")) << msg;
+}
+
+/* Brackets inside string literals (quoted and long) and comments must not
+ * terminate or unbalance the block scan. */
+TEST(Generate, BracketsInsideBlockLiterals) {
+	EXPECT_EQ("a]b[c", generateWith(
+		"a[@lua return \"]\" ]b[@lua return '[' ]c"));
+	EXPECT_EQ("x]y", generateWith("[@lua return [[x]y]] ]"));
+	EXPECT_EQ("z", generateWith("[@lua -- ]]]\nreturn 'z']"));
+	EXPECT_EQ("q\\]", generateWith("[@lua return 'q\\\\' .. ']' ]"));
+}
+
+/* A block that never closes must fail with a scanner diagnostic instead of
+ * a misleading loadstring error. */
+TEST(Generate, UnterminatedBlockAborts) {
+	std::string msg = generateError("\nx[@lua return \"unclosed");
+	EXPECT_NE(std::string::npos, msg.find("unterminated")) << msg;
+	EXPECT_NE(std::string::npos, msg.find("line 2")) << msg;
+}
+
+/* Documented marker adjacency: a backslash before [@lua emits the block
+ * verbatim; a literal '[' just before it (arr[[@lua..]]) stays intact. */
+TEST(Generate, PreservesMarkerAdjacency) {
+	EXPECT_EQ("e\\[@lua return 1]f",
+	          generateWith("e\\[@lua return 1]f"));
+	EXPECT_EQ("q[7]r", generateWith("q[[@lua return 7]]r"));
 }

--- a/test/parserTests.cpp
+++ b/test/parserTests.cpp
@@ -3,12 +3,14 @@
  *
  *  This file is part of xsd-tools.
  */
+#include <sstream>
 #include <string>
 #include <gtest/gtest.h>
 #include "src/XSDParser/Parser.hpp"
 #include "src/XSDParser/Elements/Schema.hpp"
 #include "src/XSDParser/Exception.hpp"
 #include "src/XSDParser/XsdQName.hpp"
+#include "src/xsdtools.hpp"
 
 TEST(Parser, ParsesPositiveSchema) {
 	XSD::Parser parser;
@@ -23,6 +25,36 @@ TEST(Parser, ThrowsOnMissingFile) {
 	XSD::Parser parser;
 	EXPECT_THROW(parser.Parse(std::string("/nonexistent/missing.xsd")),
 	             XSD::XMLException);
+}
+
+/* An unsupported protocol must throw — never return NULL — and must not
+ * poison the document cache: a retry of the same URI reports the same
+ * clear error rather than a stale TIXML_NO_ERROR. */
+TEST(Parser, ThrowsOnUnsupportedProtocol) {
+	XSD::Parser parser;
+	for (int attempt = 0; attempt < 2; ++attempt) {
+		try {
+			delete parser.Parse(std::string("http://example.com/x.xsd"));
+			FAIL() << "expected XMLException on attempt " << attempt;
+		} catch (const XSD::XMLException& e) {
+			EXPECT_EQ((int)XSD::XMLException::ProtocolNotSupported,
+			          e.QueryError().errorId_)
+				<< "attempt " << attempt << ": " << e.what();
+		}
+	}
+}
+
+/* xs:include resolution with a prefix-qualified root schema: the include tag
+ * must be searched under the root's XSD-lang prefix, and the searched type
+ * tag re-qualified per included document (xsd:-prefixed and default-xmlns
+ * included docs both resolve). */
+TEST(Schema, PrefixedIncludeResolvesAcrossPrefixes) {
+	std::ostringstream out;
+	ASSERT_NO_THROW(XsdTools::Generate(TEMPLATES_DIR "/test",
+		std::string(XSDPARSE_DIR "/inclPrefixed.xsd"), out));
+	/* content of the included types must appear in the generated model */
+	EXPECT_NE(std::string::npos, out.str().find("FullName"));
+	EXPECT_NE(std::string::npos, out.str().find("Sku"));
 }
 
 /* Phase 0 regression: a schema declaring no namespace at all must still

--- a/test/resourceTests.cpp
+++ b/test/resourceTests.cpp
@@ -4,8 +4,12 @@
  *  This file is part of xsd-tools.
  */
 #include <cstdlib>
+#include <fstream>
 #include <string>
 #include <gtest/gtest.h>
+#if !defined(_WIN32)
+#	include <sys/stat.h>
+#endif
 #include "src/resource.hpp"
 
 TEST(Resource, EngineScriptNonEmpty) {
@@ -21,6 +25,34 @@ TEST(Resource, ResolvesAbsoluteTemplatePath) {
 	const std::string path(TEMPLATES_DIR "/test");
 	EXPECT_EQ(path, resource.GetTemplatePath(path));
 }
+
+#if !defined(_WIN32)
+/* A template installed under $HOME/.xsdtools/templates must resolve. */
+TEST(Resource, ResolvesHomeInstalledTemplate) {
+	char homeTmpl[] = "/tmp/xsdb-home-XXXXXX";
+	ASSERT_NE((char*)NULL, mkdtemp(homeTmpl));
+	const std::string home(homeTmpl);
+	const std::string dir = home + "/.xsdtools/templates";
+	ASSERT_EQ(0, mkdir((home + "/.xsdtools").c_str(), 0700));
+	ASSERT_EQ(0, mkdir(dir.c_str(), 0700));
+	const std::string name("xsdb-home-template-test");
+	{
+		std::ofstream f((dir + "/" + name).c_str());
+		f << "-- template stub\n";
+	}
+	unsetenv("XSDTOOLS_DATA");
+	const char* pOldHome = getenv("HOME");
+	setenv("HOME", home.c_str(), 1);
+	Core::Resource resource;
+	std::string resolved;
+	EXPECT_NO_THROW(resolved = resource.GetTemplatePath(name));
+	EXPECT_EQ(dir + "/" + name, resolved);
+	if (pOldHome)
+		setenv("HOME", pOldHome, 1);
+	else
+		unsetenv("HOME");
+}
+#endif
 
 TEST(Resource, ThrowsOnMissingTemplate) {
 	/* clear the env override so the search falls through to a throw */

--- a/test/xsdparse/allMembers.xsd
+++ b/test/xsdparse/allMembers.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="person">
+		<complexType>
+			<all>
+				<annotation>
+					<documentation>member list</documentation>
+				</annotation>
+				<element name="firstName" type="string"/>
+				<element name="lastName" type="string"/>
+				<element name="age" type="int"/>
+			</all>
+		</complexType>
+	</element>
+</schema>

--- a/test/xsdparse/attrAnnotation.xsd
+++ b/test/xsdparse/attrAnnotation.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="item">
+		<complexType>
+			<attribute name="code" use="required">
+				<annotation>
+					<documentation>code attribute</documentation>
+				</annotation>
+				<simpleType>
+					<restriction base="string"/>
+				</simpleType>
+			</attribute>
+		</complexType>
+	</element>
+</schema>

--- a/test/xsdparse/elemT039.out
+++ b/test/xsdparse/elemT039.out
@@ -64,7 +64,7 @@ root = {
 					minOccurs = 1
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test3 = {
 			attributes = {}
@@ -97,7 +97,7 @@ root = {
 					minOccurs = 0
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test2 = {
 			attributes = {}
@@ -110,7 +110,7 @@ root = {
 					minOccurs = 1
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 	}
 	minOccurs = 1

--- a/test/xsdparse/elemT058.out
+++ b/test/xsdparse/elemT058.out
@@ -72,7 +72,7 @@ root = {
 					minOccurs = 1
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test1 = {
 			attributes = {}
@@ -90,7 +90,7 @@ root = {
 					minOccurs = 1
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test2 = {
 			attributes = {}
@@ -108,7 +108,7 @@ root = {
 					minOccurs = 1
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test5 = {
 			attributes = {}
@@ -141,7 +141,7 @@ root = {
 					minOccurs = 0
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 		test4 = {
 			attributes = {}
@@ -174,7 +174,7 @@ root = {
 					minOccurs = 0
 				}
 			}
-			minOccurs = 1
+			minOccurs = 0
 		}
 	}
 	minOccurs = 1

--- a/test/xsdparse/facet_override.xsd
+++ b/test/xsdparse/facet_override.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="root" type="derivedType"/>
+	<simpleType name="baseType">
+		<restriction base="string">
+			<maxLength value="100"/>
+			<pattern value="[a-z]+"/>
+			<enumeration value="alpha"/>
+			<enumeration value="beta"/>
+			<enumeration value="gamma"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="derivedType">
+		<restriction base="baseType">
+			<maxLength value="10"/>
+			<pattern value="[ab].*"/>
+			<enumeration value="alpha"/>
+			<enumeration value="beta"/>
+		</restriction>
+	</simpleType>
+</schema>

--- a/test/xsdparse/facet_precision.xsd
+++ b/test/xsdparse/facet_precision.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="counter">
+		<simpleType>
+			<restriction base="decimal">
+				<minInclusive value="2.5"/>
+				<maxInclusive value="4294967295"/>
+			</restriction>
+		</simpleType>
+	</element>
+</schema>

--- a/test/xsdparse/inclDefaultNsTypes.xsd
+++ b/test/xsdparse/inclDefaultNsTypes.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema">
+	<complexType name="ProductRec">
+		<sequence>
+			<element name="Sku" type="string"/>
+		</sequence>
+	</complexType>
+</schema>

--- a/test/xsdparse/inclPrefixed.xsd
+++ b/test/xsdparse/inclPrefixed.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="inclPrefixedTypes.xsd"/>
+	<xs:include schemaLocation="inclDefaultNsTypes.xsd"/>
+	<xs:element name="Company">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Person" type="PersonRec"/>
+				<xs:element name="Product" type="ProductRec"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/test/xsdparse/inclPrefixedTypes.xsd
+++ b/test/xsdparse/inclPrefixedTypes.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<xsd:complexType name="PersonRec">
+		<xsd:sequence>
+			<xsd:element name="FullName" type="xsd:string"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/test/xsdparse/ref_occurs.xsd
+++ b/test/xsdparse/ref_occurs.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="root">
+		<complexType>
+			<sequence>
+				<element ref="item" minOccurs="0" maxOccurs="unbounded"/>
+			</sequence>
+		</complexType>
+	</element>
+	<element name="item" type="string"/>
+</schema>

--- a/test/xsdparse/substRefInvalid.xsd
+++ b/test/xsdparse/substRefInvalid.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="head" type="int"/>
+	<element name="widen" type="integer" substitutionGroup="head"/>
+</schema>

--- a/test/xsdparse/substRefValid.xsd
+++ b/test/xsdparse/substRefValid.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<schema>
+	<element name="head" type="integer"/>
+	<element name="member" type="int" substitutionGroup="head"/>
+	<element name="narrow" substitutionGroup="head">
+		<simpleType>
+			<restriction base="int"/>
+		</simpleType>
+	</element>
+	<element name="root">
+		<complexType>
+			<sequence>
+				<element ref="member"/>
+			</sequence>
+		</complexType>
+	</element>
+</schema>


### PR DESCRIPTION
## Summary

A full bug scan of the C++ core and template engine found 12 high-severity, verified bugs; this PR fixes all of them. Every fix ships with regression tests confirmed to fail on the pre-fix code.

### Silent wrong output from valid schemas
- **`xs:all` dropped every member after the first** — `All::ParseChildren` inspected only `FirstChild()`; now iterates the sibling chain like `Sequence`/`Choice`.
- **`ref=` elements lost their `minOccurs`/`maxOccurs`** — occurs are now always read from the referencing site (a global element legally can't carry them). Two goldens (`elemT039.out`, `elemT058.out`) regenerated accordingly.
- **Base-type facets overrode derived restrictions** — facet levels now merge derived-first (`LuaFacets::mergeBase`): derived scalars win, a derived `enumeration` replaces the base's, patterns still accumulate (ANDed per XSD).
- **Numeric facet bounds rounded to 6 significant digits** — `maxInclusive=4294967295` reached templates as `4.29497e+09`; long-double facet values now print integrally or with round-trip precision.
- **Template errors were pasted into generated output with exit 0** — `parser.lua` discarded the pcall success flag; block failures (and unreadable `include` paths) now abort generation with a line-numbered error.

### Crashes / valid schemas rejected
- **`http://` schema URL segfaulted** — `Parser::Parse` returned NULL unchecked; it now throws `ProtocolNotSupported`, and failed loads no longer poison the document cache.
- **`xs:include` resolution was broken for prefix-qualified schemas** — the include scan used the literal unqualified `include` tag and the root document's prefix for type tags; both now qualify per-document, mirroring the import path.
- **`ref` to a substitution-group head threw `MissingAttribute`** — the check ran on the ref site instead of the referenced element.
- **`isTypeRelated` derivation check was direction-inverted** — valid substitution groups (member `xs:int` under head `xs:integer`) were rejected and the invalid reverse accepted; fixed with a double-dispatch `isBaseTypeOf` helper.
- **Annotation children of `xs:attribute` were `static_cast` to `SimpleType`** — children now dispatch through `ParseElement` double dispatch.
- **`~/.xsdtools/templates` never resolved** — missing path separator built `$HOME//.xsdtools/templatesNAME`; `--list` and lookup now agree. `homeDir_()` also honors `$HOME` before `getpwuid`.
- **`[@lua]` block scanning broke on brackets inside string literals** — the quote-blind `%b[]` match is replaced by a lexer tracking quoted strings, long strings/comments, and bracket depth; unterminated blocks fail with a clear line-numbered error.

## Tests
18 new regression tests across `facetTests.cpp`, `generateTests.cpp`, `parserTests.cpp`, `resourceTests.cpp`, and a new `elementTests.cpp`, plus 12 fixture schemas under `test/xsdparse/`. Full suite (787 tests incl. all round-trip families) passes on a clean build; TsXml round-trips skip locally (no node/npm), all other families green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/xsd-tools/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785543516&installation_id=141995922&pr_number=76&repository=QVXLabs%2Fxsd-tools&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fxsd-tools%2Fpull%2F76&signature=c503af620b50ceeb9a17e94d1758e40b3d5619093511c196811c93e539c43908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->